### PR TITLE
Made the doc type update when the markup is changed

### DIFF
--- a/ReText/window.py
+++ b/ReText/window.py
@@ -631,7 +631,10 @@ class ReTextWindow(QMainWindow):
 			self.menuRecentFiles.addAction(action)
 
 	def markupFunction(self, markup):
-		return lambda: self.setDefaultMarkup(markup)
+		def run():
+			self.setDefaultMarkup(markup)
+			self.docTypeChanged()
+		return run
 
 	def openFunction(self, fileName):
 		return lambda: self.openFileWrapper(fileName)


### PR DESCRIPTION
When you change the default markup type, it should change things like making the tags and symbols enabled/disabled, etc.  Currently it does not, but this pull request seems to fix that.

In terms of testing, I ran the program and changed the markup type and it seemed to work.