### PR TITLE
QT_SELECT=5 instead of QT_SELECT=qt5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ def build_translations():
 	error = None
 	for ts_file in glob(join('locale', '*.ts')):
 		try:
-			check_call(('lrelease', ts_file), env={'QT_SELECT': 'qt5'})
+			check_call(('lrelease', ts_file), env={'QT_SELECT': '5'})
 		except Exception as e:
 			error = e
 	if error:


### PR DESCRIPTION
The `setup.py` calls `lrelease` with `QT_SELECT=qt5` set.
On Arch Linux this will error with:
> lrelease: could not find a Qt installation of 'qt5'

The output of `qtchooser -list-versions` on Arch Linux is:
> 4
> 5
> default

This is the same for
[LFS](http://www.linuxfromscratch.org/blfs/view/7.4/general/qtchooser.html)

This fix changed "qt5" to "5".