### PR TITLE
Auto detect encoding

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -116,7 +116,7 @@ setup(name='ReText',
         ('share/retext/locale', iglob('locale/*.qm'))
       ],
       requires=['docutils', 'Markdown', 'Markups', 'pyenchant', 'Pygments'],
-      install_requires=['docutils', 'Markdown', 'Markups>=2.0', 'pyenchant', 'Pygments'],
+      install_requires=['docutils', 'Markdown', 'Markups>=2.0', 'pyenchant', 'Pygments', 'chardet>=2.3.0'],
       cmdclass={
         'build': retext_build,
         'sdist': retext_sdist,


### PR DESCRIPTION
I have lots *.rst file in UTF-8 encoding, but while I open it, it display as jumbly characters until I “Set encoding" to "UTF-8" and reload it again. After go around the source codes, I found  retext will load the file with defaultCodec which be initialized to system encoding, but my system encoding is "GBK".

So if I load a file which content encoding different from defaultCodec, it will be displayed as jumbly characters until I set the encoding correct manually.

That's not the end: even I set the encoding correctly, all things seems display correctly, but after I save that file, it will be converted to defaultCodec (which is GBK). So now my UTF-8 encoding file be converted to a GBK encoding file.

I modified those routines about encoding parts:

1. Added encoding auto detect behavior before file loading and pass the detected encoding to QTextStream
2. Saved detected encoding to document object 
3. Save the file by detected encoding which buffered in the document object 

Now the file encoding load as is and save as it, and seems that we need not set the encoding manually.

This only tested on python3.4.3 on Win10 x64 with Chinese language.
