### PR TITLE
Generate directly callable script in windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ class retext_install_scripts(install_scripts):
 				# script directly from command line
 				batch_script = "@echo off\n%s %s %%*" % (sys.executable, renamed_file)
 				with open("%s.bat" % renamed_file, "w") as bat_file:
-    				bat_file.write(batch_script)
+					bat_file.write(batch_script)
 
 class retext_test(Command):
 	user_options = []

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ For more details, please go to the `home page`_ or to the `wiki`_.
 
 import re
 import sys
+import os.path
 from os.path import join
 from distutils import log
 from distutils.core import setup, Command
@@ -57,8 +58,16 @@ class retext_install_scripts(install_scripts):
 		import shutil
 		install_scripts.run(self)
 		for file in self.get_outputs():
-			log.info('renaming %s to %s', file, file[:-3])
-			shutil.move(file, file[:-3])
+			renamed_file = file[:-3]
+
+			log.info('renaming %s to %s', file, renamed_file)
+			shutil.move(file, renamed_file)
+
+			if sys.platform == "win32":
+				# Generate batch script for warpper the python script so we could invoke that
+				# script directly from command line
+				batch_script = "@echo off\n%s %s %%*" % (sys.executable, renamed_file)
+				open("%s.bat" %  renamed_file, "wb").write(batch_script.encode())
 
 class retext_test(Command):
 	user_options = []

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ For more details, please go to the `home page`_ or to the `wiki`_.
 
 import re
 import sys
-import os.path
+
 from os.path import join
 from distutils import log
 from distutils.core import setup, Command
@@ -64,10 +64,11 @@ class retext_install_scripts(install_scripts):
 			shutil.move(file, renamed_file)
 
 			if sys.platform == "win32":
-				# Generate batch script for warpper the python script so we could invoke that
+				# Generate batch script for wrapper the python script so we could invoke that
 				# script directly from command line
 				batch_script = "@echo off\n%s %s %%*" % (sys.executable, renamed_file)
-				open("%s.bat" %  renamed_file, "wb").write(batch_script.encode())
+				with open("%s.bat" % renamed_file, "w") as bat_file:
+    				bat_file.write(batch_script)
 
 class retext_test(Command):
 	user_options = []


### PR DESCRIPTION
After installed retext by pip or setup.py, you must invoke it manually from command line in Scripts directory: "python retext". I think it's better to generate a simple wrapper batch script in Scripts directory, so that ReText will more like a program in windows (at least working just like the other scripts in Scripts directory).