### PR TITLE
Close current tab with Ctrl+W

### DIFF
--- a/ReText/window.py
+++ b/ReText/window.py
@@ -112,6 +112,8 @@ class ReTextWindow(QMainWindow):
 			lambda: self.switchTab(1), shct=Qt.CTRL+Qt.Key_PageDown)
 		self.actionPrevTab = self.act(self.tr('Previous tab'), 'go-previous',
 			lambda: self.switchTab(-1), shct=Qt.CTRL+Qt.Key_PageUp)
+		self.actionCloseCurrentTab = self.act(self.tr('Close tab'), 'window-close',
+			lambda: self.closeCurrentTab(), shct=Qt.CTRL + Qt.Key_W)
 		self.actionPrint = self.act(self.tr('Print'), 'document-print',
 			self.printFile, shct=QKeySequence.Print)
 		self.actionPrint.setPriority(QAction.LowPriority)
@@ -263,6 +265,7 @@ class ReTextWindow(QMainWindow):
 		menuFile.addSeparator()
 		menuFile.addAction(self.actionNextTab)
 		menuFile.addAction(self.actionPrevTab)
+		menuFile.addAction(self.actionCloseCurrentTab)
 		menuFile.addSeparator()
 		menuExport = menuFile.addMenu(self.tr('Export'))
 		menuExport.addAction(self.actionSaveHtml)
@@ -501,6 +504,9 @@ class ReTextWindow(QMainWindow):
 				self.fileSystemWatcher.removePath(closedTab.fileName)
 			self.tabWidget.removeTab(ind)
 			closedTab.deleteLater()
+
+	def closeCurrentTab(self):
+		self.closeTab(self.ind)
 
 	def changeIndex(self, ind):
 		'''

--- a/locale/retext_fr.ts
+++ b/locale/retext_fr.ts
@@ -227,6 +227,11 @@
         <translation>Onglet précédent</translation>
     </message>
     <message>
+        <location filename="window.py" line="113"/>
+        <source>Close tab</source>
+        <translation>Fermer l'onglet</translation>
+    </message>
+    <message>
         <location filename="window.py" line="115"/>
         <source>Print</source>
         <translation>Imprimer</translation>


### PR DESCRIPTION
This adds the ability to quickly close an open tab from a keyboard shortcut without having to use the mouse