### PR TITLE
Handle quote blocks when handling return

### DIFF
--- a/ReText/editor.py
+++ b/ReText/editor.py
@@ -219,7 +219,7 @@ class ReTextEdit(QTextEdit):
 		length = len(text)
 		pos = 0
 		while pos < length and (text[pos] in (' ', '\t')
-		  or text[pos:pos+2] in ('* ', '- ')):
+		  or text[pos:pos+2] in ('* ', '- ', '> ')):
 			pos += 1
 		if pos == length:
 			cursor.removeSelectedText()


### PR DESCRIPTION
Handle quote block the same way lists are handle : a first return key will automatically fill the line with a starting `>`, and a second one will replace the line with a blank one. 