### PR TITLE
Implement softwrapping at user specified margin line

### DIFF
--- a/ReText/__init__.py
+++ b/ReText/__init__.py
@@ -84,6 +84,7 @@ configOptions = {
 	'relativeLineNumbers': False,
 	'restDefaultFileExtension': '.rst',
 	'rightMargin': 0,
+	'rightMarginWrap': False,
 	'saveWindowGeometry': False,
 	'spellCheck': False,
 	'spellCheckLocale': '',

--- a/ReText/config.py
+++ b/ReText/config.py
@@ -84,7 +84,7 @@ class ConfigDialog(QDialog):
 			(self.tr('Tab key inserts spaces'), 'tabInsertsSpaces'),
 			(self.tr('Tabulation width'), 'tabWidth'),
 			(self.tr('Draw vertical line at column'), 'rightMargin'),
-            (self.tr('Enable soft wrap'), 'rightMarginWrap'),
+			(self.tr('Enable soft wrap'), 'rightMarginWrap'),
 			(self.tr('Show document stats'), 'documentStatsEnabled'),
 			(self.tr('Interface'), None),
 			(self.tr('Icon theme name'), 'iconTheme'),
@@ -124,7 +124,7 @@ class ConfigDialog(QDialog):
 			if isinstance(value, bool):
 				self.configurators[name] = QCheckBox(self)
 				self.configurators[name].setChecked(value)
-				if name == 'rightMarginWrap' and getattr(globalSettings, 'rightMargin') == 0:
+				if name == 'rightMarginWrap' and (globalSettings.rightMargin == 0):
 					self.configurators[name].setEnabled(False)
 			elif isinstance(value, int):
 				self.configurators[name] = QSpinBox(self)
@@ -144,7 +144,7 @@ class ConfigDialog(QDialog):
 	def handleRightMarginSet(self, value):
 		if value > 0:
 			self.configurators['rightMarginWrap'].setEnabled(True)
-			self.configurators['rightMarginWrap'].setChecked(getattr(globalSettings, 'rightMarginWrap'))
+			self.configurators['rightMarginWrap'].setChecked(globalSettings.rightMarginWrap)
 		else:
 			self.configurators['rightMarginWrap'].setChecked(False)
 			self.configurators['rightMarginWrap'].setEnabled(False)

--- a/ReText/config.py
+++ b/ReText/config.py
@@ -60,6 +60,7 @@ class ConfigDialog(QDialog):
 		buttonBox.accepted.connect(self.saveSettings)
 		buttonBox.rejected.connect(self.close)
 		self.initWidgets()
+		self.configurators['rightMargin'].valueChanged.connect(self.handleRightMarginSet)
 		self.layout.addWidget(buttonBox, len(self.options), 0, 1, 2)
 
 	def initConfigOptions(self):
@@ -123,6 +124,8 @@ class ConfigDialog(QDialog):
 			if isinstance(value, bool):
 				self.configurators[name] = QCheckBox(self)
 				self.configurators[name].setChecked(value)
+				if name == 'rightMarginWrap' and getattr(globalSettings, 'rightMargin') == 0:
+					self.configurators[name].setEnabled(False)
 			elif isinstance(value, int):
 				self.configurators[name] = QSpinBox(self)
 				if name == 'tabWidth':
@@ -137,6 +140,14 @@ class ConfigDialog(QDialog):
 				self.configurators[name].setText(value)
 			self.layout.addWidget(label, index, 0)
 			self.layout.addWidget(self.configurators[name], index, 1, Qt.AlignRight)
+
+	def handleRightMarginSet(self, value):
+		if value > 0:
+			self.configurators['rightMarginWrap'].setEnabled(True)
+			self.configurators['rightMarginWrap'].setChecked(getattr(globalSettings, 'rightMarginWrap'))
+		else:
+			self.configurators['rightMarginWrap'].setChecked(False)
+			self.configurators['rightMarginWrap'].setEnabled(False)
 
 	def saveSettings(self):
 		for option in self.options:
@@ -171,5 +182,6 @@ class ConfigDialog(QDialog):
 			print(e, file=sys.stderr)
 		for tab in self.parent.iterateTabs():
 			tab.editBox.updateFont()
+			tab.editBox.setWrapModeAndWidth()
 			tab.editBox.viewport().update()
 		self.parent.updateStyleSheet()

--- a/ReText/config.py
+++ b/ReText/config.py
@@ -83,6 +83,7 @@ class ConfigDialog(QDialog):
 			(self.tr('Tab key inserts spaces'), 'tabInsertsSpaces'),
 			(self.tr('Tabulation width'), 'tabWidth'),
 			(self.tr('Draw vertical line at column'), 'rightMargin'),
+            (self.tr('Enable soft wrap'), 'rightMarginWrap'),
 			(self.tr('Show document stats'), 'documentStatsEnabled'),
 			(self.tr('Interface'), None),
 			(self.tr('Icon theme name'), 'iconTheme'),

--- a/ReText/editor.py
+++ b/ReText/editor.py
@@ -114,10 +114,9 @@ class ReTextEdit(QTextEdit):
 			self.installFakeVimHandler()
 
 	def setWrapModeAndWidth(self):
-		if globalSettings.rightMarginWrap:
-			if self.rect().topRight().x() > self.marginx:
-				self.setLineWrapMode(2)
-				self.setLineWrapColumnOrWidth(self.marginx)
+		if globalSettings.rightMarginWrap and (self.rect().topRight().x() > self.marginx):
+			self.setLineWrapMode(2)
+			self.setLineWrapColumnOrWidth(self.marginx)
 		else:
 			self.setLineWrapMode(1)
 

--- a/ReText/editor.py
+++ b/ReText/editor.py
@@ -106,11 +106,20 @@ class ReTextEdit(QTextEdit):
 		self.statistics = (0, 0, 0)
 		self.statsArea = TextInfoArea(self)
 		self.updateFont()
+		self.setWrapModeAndWidth()
 		self.document().blockCountChanged.connect(self.updateLineNumberAreaWidth)
 		self.cursorPositionChanged.connect(self.highlightCurrentLine)
 		self.document().contentsChange.connect(self.contentsChange)
 		if globalSettings.useFakeVim:
 			self.installFakeVimHandler()
+
+	def setWrapModeAndWidth(self):
+		if globalSettings.rightMarginWrap:
+			if self.rect().topRight().x() < self.marginx:
+				self.setLineWrapMode(1)
+			else:
+				self.setLineWrapMode(2)
+				self.setLineWrapColumnOrWidth(self.marginx)
 
 	def updateFont(self):
 		self.setFont(globalSettings.editorFont)
@@ -250,6 +259,7 @@ class ReTextEdit(QTextEdit):
 			self.lineNumberAreaWidth(), rect.height())
 		self.infoArea.updateTextAndGeometry()
 		self.statsArea.updateTextAndGeometry()
+		self.setWrapModeAndWidth()
 
 	def highlightCurrentLine(self):
 		if globalSettings.relativeLineNumbers:
@@ -495,4 +505,3 @@ class TextInfoArea(InfoArea):
 		                   'count of words, alphanumeric characters, all characters')
 		words, alphaNums, characters = self.editor.statistics
 		return template % (words, alphaNums, characters)
-

--- a/ReText/editor.py
+++ b/ReText/editor.py
@@ -115,11 +115,11 @@ class ReTextEdit(QTextEdit):
 
 	def setWrapModeAndWidth(self):
 		if globalSettings.rightMarginWrap:
-			if self.rect().topRight().x() < self.marginx:
-				self.setLineWrapMode(1)
-			else:
+			if self.rect().topRight().x() > self.marginx:
 				self.setLineWrapMode(2)
 				self.setLineWrapColumnOrWidth(self.marginx)
+		else:
+			self.setLineWrapMode(1)
 
 	def updateFont(self):
 		self.setFont(globalSettings.editorFont)

--- a/ReText/editor.py
+++ b/ReText/editor.py
@@ -115,10 +115,10 @@ class ReTextEdit(QTextEdit):
 
 	def setWrapModeAndWidth(self):
 		if globalSettings.rightMarginWrap and (self.rect().topRight().x() > self.marginx):
-			self.setLineWrapMode(2)
+			self.setLineWrapMode(QTextEdit.FixedPixelWidth)
 			self.setLineWrapColumnOrWidth(self.marginx)
 		else:
-			self.setLineWrapMode(1)
+			self.setLineWrapMode(QTextEdit.WidgetWidth)
 
 	def updateFont(self):
 		self.setFont(globalSettings.editorFont)


### PR DESCRIPTION
As I started using ReText more often, I noticed that I missed the softwrap option of Atom.

This pull request implements a simple softwrap feature and creates the necessary preferences entry. Moreover, it can take into account whether the width of ReTextEdit(QTextEdit) is smaller than user specified margin.