### PR TITLE
tablemode fixes for restruturedtext tables 

### DIFF
--- a/ReText/tablemode.py
+++ b/ReText/tablemode.py
@@ -58,12 +58,11 @@ def _getTableLines(doc, pos, markupClass):
 				row.separatorline = True
 				row.paddingchar = '-'
 	elif markupClass == ReStructuredTextMarkup:
-		for i, row in enumerate(rows):
-			if i & 1 == 0: # i is even
+		for row in rows:
+			if row.text.strip().startswith(('+-','+=')):
 				row.separatorline = True
-				row.paddingchar = '=' if (i == 2) else '-'
+				row.paddingchar = row.text.strip()[1]
 				row.text = row.text.replace('+', '|')
-
 	return rows, editedlineindex, offset
 
 def _sortaUndoEdit(rows, editedlineindex, editsize):


### PR DESCRIPTION
With tablemode activated I noticed tables broke once restructuredtext tables contained rows consisting of multiple lines.

It can be seen when using the following table:
```
   +--------+---------------------------------------------------------+
   | Header | If this is 2 rows, it will show the same error          |
   +========+=========================================================+
   | single | All is still good                                       |
   +--------+---------------------------------------------------------+
   | double | Next one will break when changing text.                 |
   |        | Make sure breakage is not due to an empty line          |
   +--------+---------------------------------------------------------+
   | single | Will still show a wrong line                            |
   +--------+---------------------------------------------------------+
   | double | Lines are odd again, next one will be fine              |
   |        |                                                         |
   +--------+---------------------------------------------------------+
   | single | Everything ok                                           |
   +--------+---------------------------------------------------------+
   | double | DELETE ME to remove content as well (even line)         |
   |        | DELETE ME PLEASE to show errors in gridlines (odd line) |
   +--------+---------------------------------------------------------+
   | single | INSERT TEXT to remove content when a line is long       |
   +--------+---------------------------------------------------------+
   | single | Just to prove it is not due to being the bottom line    |
   +--------+---------------------------------------------------------+
```

Deleting would produce tables like:
```
   +--------+------------------------------------------------+
   | Header | If this is 2 rows, it will show the same error |
   +========+================================================+
   | single | All is still good                              |
   +--------+------------------------------------------------+
   | double | Next one will break when changing text.        |
   |        | Make sure breakage is not due to an empty line |
   +--------+---------------------------------------------------------+
   | single | Will still show a wrong line                   |
   +--------+---------------------------------------------------------+
   | double | Lines are odd again, next one will be fine     |
   |        |                                                |
   +--------+------------------------------------------------+
   | single | Everything ok                                  |
   +--------+------------------------------------------------+
   | double |  to remove content as well (even line)         |
   |        | DELETE ME PLEASE to show errors in gridlines ( |
   +--------+---------------------------------------------------------+
   | single | INSERT TEXT to remove content when a line is l |
   +--------+---------------------------------------------------------+
   | single | Just to prove it is not due to being the botto |
   +--------+---------------------------------------------------------+
```
or
```
   +--------+------------------------------------------------+
   | Header | If this is 2 rows, it will show the same error |
   +========+================================================+
   | single | All is still good                              |
   +--------+------------------------------------------------+
   | double | Next one will break when changing text.        |
   |        | Make sure breakage is not due to an empty line |
   +--------+---------------------------------------------------------+
   | single | Will still show a wrong line                   |
   +--------+---------------------------------------------------------+
   | double | Lines are odd again, next one will be fine     |
   |        |                                                |
   +--------+------------------------------------------------+
   | single | Everything ok                                  |
   +--------+------------------------------------------------+
   | double | DELETE ME to remove content as well (even line)|
   |        |  to show errors in gridlines (odd line)------- |
   +--------+---------------------------------------------------------+
   | single | INSERT TEXT to remove content when a line is l |
   +--------+---------------------------------------------------------+
   | single | Just to prove it is not due to being the botto |
   +--------+---------------------------------------------------------+
```

Inserting  would produce:
```
   +--------+---------------------------------------------------------+
   | Header | If this is 2 rows, it will show the same error          |
   +========+=========================================================+
   | single | All is still good                                       |
   +--------+---------------------------------------------------------+
   | double | Next one will break when changing text.                 |
   |        | Make sure breakage is not due to an empty line          |
   +--------+---------------------------------------------------------+
   | single | Will still show a wrong line                            |
   +--------+---------------------------------------------------------+
   | double | Lines are odd again, next one will be fine              |
   |        |                                                         |
   +--------+---------------------------------------------------------+
   | single | Everything ok                                           |
   +--------+---------------------------------------------------------+
   | double | DELETE ME to remove content as well (even line)         |
   |        | DELETE ME PLEASE to show errors in gridlines (odd line) |
   +--------+---------------------------------------------------------+
   | single | INSERT INSERT TEXT to remove content when a line is kin |
   +--------+---------------------------------------------------------+
   | single | Just to prove it is not due to being the bottom line    |
   +--------+---------------------------------------------------------+
```

This was tested using the latest master.

The fix from this PR would prevent the latter three errors.

Kind regards