### PR TITLE
Use the WaveUnderline style to mark spellcheck errors

### DIFF
--- a/ReText/highlighter.py
+++ b/ReText/highlighter.py
@@ -155,7 +155,7 @@ class ReTextHighlighter(QSyntaxHighlighter):
 		if self.dictionary:
 			charFormat = QTextCharFormat()
 			charFormat.setUnderlineColor(Qt.red)
-			charFormat.setUnderlineStyle(QTextCharFormat.SpellCheckUnderline)
+			charFormat.setUnderlineStyle(QTextCharFormat.WaveUnderline)
 			for match in reWords.finditer(text):
 				finalFormat = QTextCharFormat()
 				finalFormat.merge(charFormat)


### PR DESCRIPTION
Fixes #329

It seems like this is a Qt bug, making the SpellCheckUnderline disappear
when the font is bigger than 16 pt. Any other underline style works
correctly.

There is an existing bug report on this :
https://bugreports.qt.io/browse/QTBUG-50499