### PR TITLE
ENH: Add paperSize global setting 

### DIFF
--- a/ReText/__init__.py
+++ b/ReText/__init__.py
@@ -98,7 +98,7 @@ configOptions = {
 	'useWebEngine': False,
 	'useWebKit': False,
 	'windowGeometry': QByteArray(),
-	'paperSize': 'A4',
+	'paperSize': '',
 }
 
 def readFromSettings(key, keytype, settings=settings, default=None):

--- a/ReText/__init__.py
+++ b/ReText/__init__.py
@@ -98,6 +98,7 @@ configOptions = {
 	'useWebEngine': False,
 	'useWebKit': False,
 	'windowGeometry': QByteArray(),
+	'paperSize': 'A4',
 }
 
 def readFromSettings(key, keytype, settings=settings, default=None):

--- a/ReText/window.py
+++ b/ReText/window.py
@@ -950,23 +950,22 @@ class ReTextWindow(QMainWindow):
 				printer.setPaperSize(pageSize)
 			else:
 				QMessageBox.warning(self, '',
-					self.tr('Unrecognized PaperSize setting "%s".' %
-					globalSettings.paperSize))
+					self.tr('Unrecognized PaperSize setting "%s".') %
+					globalSettings.paperSize)
 		return printer
 
 	def getPageSizeByName(self, pageSizeName):
-		""" Returns a validated PageSize instance
-		corresponding to the given name. Returns
-		None if the name is not a valid PageSize.
+		""" Returns a validated PageSize instance corresponding to the given 
+        name. Returns None if the name is not a valid PageSize.
 		"""
-
+		
 		pageSize = None
-		match = None
-		if pageSizeName:
-			match = list(filter(lambda y:y.lower()==pageSizeName.lower(),
-						self.availablePageSizes()))
-		if match:
-			pageSize = getattr(QPagedPaintDevice, match[0])
+        
+		lowerCaseNames = {pageSize.lower(): pageSize for pageSize in 
+						  self.availablePageSizes()}
+		if pageSizeName.lower() in lowerCaseNames:
+			pageSize = getattr(QPagedPaintDevice, lowerCaseNames[pageSizeName])
+
 		return pageSize
 
 	def availablePageSizes(self):

--- a/ReText/window.py
+++ b/ReText/window.py
@@ -944,29 +944,30 @@ class ReTextWindow(QMainWindow):
 		printer = QPrinter(QPrinter.HighResolution)
 		printer.setDocName(title)
 		printer.setCreator('ReText %s' % app_version)
-		page_size = self.getPageSizeByName(globalSettings.paperSize)
-		if page_size is not None:
-		    printer.setPaperSize(page_size)
-		else:
-		    QMessageBox.warning(self, '',
-				'Unrecognized PaperSize setting "{0}".'.format(
-				globalSettings.paperSize))
+		if globalSettings.paperSize:
+			pageSize = self.getPageSizeByName(globalSettings.paperSize)
+			if pageSize is not None:
+				printer.setPaperSize(pageSize)
+			else:
+				QMessageBox.warning(self, '',
+					self.tr('Unrecognized PaperSize setting "%s".' %
+					globalSettings.paperSize))
 		return printer
 
-	def getPageSizeByName(self, page_size_name):
+	def getPageSizeByName(self, pageSizeName):
 		""" Returns a validated PageSize instance
 		corresponding to the given name. Returns
 		None if the name is not a valid PageSize.
 		"""
 
-		page_size = None
+		pageSize = None
 		match = None
-		if page_size_name:
-			match = list(filter(lambda y:y.lower()==page_size_name.lower(),
+		if pageSizeName:
+			match = list(filter(lambda y:y.lower()==pageSizeName.lower(),
 						self.availablePageSizes()))
 		if match:
-			page_size = getattr(QPagedPaintDevice, match[0])
-		return page_size
+			pageSize = getattr(QPagedPaintDevice, match[0])
+		return pageSize
 
 	def availablePageSizes(self):
 		""" List available page sizes.

--- a/ReText/window.py
+++ b/ReText/window.py
@@ -42,7 +42,8 @@ except ImportError:
 from PyQt5.QtCore import QDir, QFile, QFileInfo, QFileSystemWatcher, \
  QIODevice, QLocale, QTextCodec, QTextStream, QTimer, QUrl, Qt
 from PyQt5.QtGui import QColor, QDesktopServices, QIcon, \
- QKeySequence, QPalette, QTextDocument, QTextDocumentWriter
+ QKeySequence, QPalette, QTextDocument, QTextDocumentWriter, \
+ QPagedPaintDevice
 from PyQt5.QtWidgets import QAction, QActionGroup, QApplication, QCheckBox, \
  QComboBox, QDesktopWidget, QDialog, QFileDialog, QFontDialog, QInputDialog, \
  QLineEdit, QMainWindow, QMenu, QMessageBox, QTabWidget, QToolBar
@@ -943,7 +944,38 @@ class ReTextWindow(QMainWindow):
 		printer = QPrinter(QPrinter.HighResolution)
 		printer.setDocName(title)
 		printer.setCreator('ReText %s' % app_version)
+		page_size = self.getPageSizeByName(globalSettings.paperSize)
+		if page_size is not None:
+		    printer.setPaperSize(page_size)
+		else:
+		    QMessageBox.warning(self, '',
+				'Unrecognized PaperSize setting "{0}".'.format(
+				globalSettings.paperSize))
 		return printer
+
+	def getPageSizeByName(self, page_size_name):
+		""" Returns a validated PageSize instance
+		corresponding to the given name. Returns
+		None if the name is not a valid PageSize.
+		"""
+
+		page_size = None
+		match = None
+		if page_size_name:
+			match = list(filter(lambda y:y.lower()==page_size_name.lower(),
+						self.availablePageSizes()))
+		if match:
+			page_size = getattr(QPagedPaintDevice, match[0])
+		return page_size
+
+	def availablePageSizes(self):
+		""" List available page sizes.
+		"""
+
+		sizes = [x for x in dir(QPagedPaintDevice)
+				 if type(getattr(QPagedPaintDevice,x)) ==
+				 QPagedPaintDevice.PageSize]
+		return sizes
 
 	def savePdf(self):
 		fileName = QFileDialog.getSaveFileName(self,

--- a/configuration.md
+++ b/configuration.md
@@ -27,6 +27,7 @@ option name                    | type      | description
 `livePreviewByDefault`         | boolean   | whether new tabs and windows should open in live preview mode (default: false)
 `markdownDefaultFileExtension` | string    | default file extension for Markdown files (default: `.mkd`)
 `pygmentsStyle`                | string    | name of Pygments syntax highlighting style to use (default: `default`)
+`paperSize`                    | string    | name of default page size to use for print and export (e.g. A4, Letter)
 `relativeLineNumbers`          | boolean   | whether to show line numbers as relative from the current line (default: false)
 `restDefaultFileExtension`     | string    | default file extension for reStructuredText files (default: `.rst`)
 `rightMargin`                  | integer   | enable drawing of vertical line on defined position (or 0 to disable)


### PR DESCRIPTION
Adds paperSize global setting which sets both the default paper size for both the quick PDF export and the more interactive print dialog.

Reference issue #205 