### PR TITLE
Asciimath poc

### DIFF
--- a/ReText/tab.py
+++ b/ReText/tab.py
@@ -203,9 +203,17 @@ class ReTextTab(QSplitter):
 			headers += ('<link rel="stylesheet" type="text/css" href="%s">\n'
 			% cssFileName)
 		headers += ('<meta name="generator" content="ReText %s">\n' % app_version)
-		return converted.get_whole_html(
+		html = converted.get_whole_html(
 			custom_headers=headers, include_stylesheet=includeStyleSheet,
 			fallback_title=baseName, webenv=webenv)
+		old_mathjax = '<script type="text/javascript" src="file:///usr/share/javascript/mathjax/MathJax.js"></script>'
+		new_mathjax = """
+			    	  <script type="text/javascript" async src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=AM_HTMLorMML">
+			    	  </script>\n
+					  """
+		html = html.replace(old_mathjax,new_mathjax)
+		
+		return html
 
 	def getDocumentForExport(self, includeStyleSheet, webenv):
 		markupClass = self.getActiveMarkupClass()

--- a/ReText/tab.py
+++ b/ReText/tab.py
@@ -207,10 +207,10 @@ class ReTextTab(QSplitter):
 			custom_headers=headers, include_stylesheet=includeStyleSheet,
 			fallback_title=baseName, webenv=webenv)
 		old_mathjax = '<script type="text/javascript" src="file:///usr/share/javascript/mathjax/MathJax.js"></script>'
-        new_mathjax = """
-                      <script type="text/javascript" async src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=AM_HTMLorMML">
-                      </script>\n
-                      """
+		new_mathjax = """
+			    	  <script type="text/javascript" async src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=AM_HTMLorMML">
+			    	  </script>\n
+					  """
 		html = html.replace(old_mathjax,new_mathjax)
 		
 		return html

--- a/ReText/tab.py
+++ b/ReText/tab.py
@@ -207,10 +207,10 @@ class ReTextTab(QSplitter):
 			custom_headers=headers, include_stylesheet=includeStyleSheet,
 			fallback_title=baseName, webenv=webenv)
 		old_mathjax = '<script type="text/javascript" src="file:///usr/share/javascript/mathjax/MathJax.js"></script>'
-		new_mathjax = """
-			    	  <script type="text/javascript" async src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=AM_HTMLorMML">
-			    	  </script>\n
-					  """
+        new_mathjax = """
+                      <script type="text/javascript" async src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=AM_HTMLorMML">
+                      </script>\n
+                      """
 		html = html.replace(old_mathjax,new_mathjax)
 		
 		return html


### PR DESCRIPTION
Adds a proof of concept for AsciiMath for issue #236 .

Since forward slash in markdown indicates inline code, but in AsciiMath indicates math markup, users would just need to escape their forward slashes (i.e. using \\` )

![image](https://user-images.githubusercontent.com/24377848/31899063-846e5452-b7cf-11e7-99bb-6ddbbb8f0bd1.png)


```
Code in LaTeX
    \begin{equation}
    \int_{a}^{b}x^{2}dx = \frac{1}{3}x^{3} + C
    \end{equation}


AsciiMath Example 1

\`[[a,b],[c,d]]\`

AsciiMath Example 2

\`sum_(i=1)^n i^3=((n(n+1))/2)^2\`
```
