### PR TITLE
linux: Add 'StartupWMClass' to the desktop file

### DIFF
--- a/data/me.mitya57.ReText.desktop
+++ b/data/me.mitya57.ReText.desktop
@@ -28,5 +28,6 @@ Categories=Office;WordProcessor;
 Exec=retext %F
 Type=Application
 Icon=retext
+StartupWMClass=ReText
 MimeType=text/markdown;text/x-rst;
 Keywords=Text;Editor;Markdown;reStructuredText;


### PR DESCRIPTION
Fixes the icon double appearing in docks and fixes the ability of pinning to panel in Budgie.

In Solus someone reported that the ReText icon was appearing twice in docks, additionally, you could not pin the ReText application to the panel in Budgie desktop. Adding `StartupWMClass` to the desktop file resolves these issues.

Solus bug report: https://dev.solus-project.com/T5091

Signed-off-by: Joey Riches <josephriches@gmail.com>