### PR TITLE
Implement the ‘Go to line’ feature (#372)

### DIFF
--- a/ReText/tab.py
+++ b/ReText/tab.py
@@ -389,6 +389,12 @@ class ReTextTab(QSplitter):
 
 		return result
 
+	def goToLine(self,line):
+		block = self.editBox.document().findBlockByLineNumber(line)
+		if block.isValid():
+			newCursor = QTextCursor(block)
+			self.editBox.setTextCursor(newCursor)
+
 	def find(self, text, flags, replaceText=None, wrap=False):
 		cursor = self.editBox.textCursor()
 		if wrap and flags & QTextDocument.FindBackward:

--- a/ReText/window.py
+++ b/ReText/window.py
@@ -127,6 +127,8 @@ class ReTextWindow(QMainWindow):
 			trig=self.changePreviewFont)
 		self.actionSearch = self.act(self.tr('Find text'), 'edit-find',
 			self.search, shct=QKeySequence.Find)
+		self.actionGoToLine = self.act(self.tr('Go to line'),
+			trig=self.goToLine, shct=Qt.CTRL+Qt.Key_G)
 		self.searchBar.visibilityChanged.connect(self.searchBarVisibilityChanged)
 		self.actionPreview = self.act(self.tr('Preview'), shct=Qt.CTRL+Qt.Key_E,
 			trigbool=self.preview)
@@ -301,6 +303,7 @@ class ReTextWindow(QMainWindow):
 			menuSC.addAction(self.actionEnableSC)
 			menuSC.addAction(self.actionSetLocale)
 		menuEdit.addAction(self.actionSearch)
+		menuEdit.addAction(self.actionGoToLine)
 		menuEdit.addAction(self.actionChangeEditorFont)
 		menuEdit.addAction(self.actionChangePreviewFont)
 		menuEdit.addSeparator()
@@ -649,6 +652,11 @@ class ReTextWindow(QMainWindow):
 	def search(self):
 		self.searchBar.setVisible(True)
 		self.searchEdit.setFocus(Qt.ShortcutFocusReason)
+
+	def goToLine(self):
+		line, ok = QInputDialog.getInt(self, self.tr("Go to line"), self.tr("Type the line number"))
+		if ok:
+			self.currentTab.goToLine(line)
 
 	def searchBarVisibilityChanged(self, visible):
 		if visible:

--- a/ReText/window.py
+++ b/ReText/window.py
@@ -656,7 +656,7 @@ class ReTextWindow(QMainWindow):
 	def goToLine(self):
 		line, ok = QInputDialog.getInt(self, self.tr("Go to line"), self.tr("Type the line number"))
 		if ok:
-			self.currentTab.goToLine(line)
+			self.currentTab.goToLine(line-1)
 
 	def searchBarVisibilityChanged(self, visible):
 		if visible:

--- a/locale/retext_fr.ts
+++ b/locale/retext_fr.ts
@@ -258,6 +258,16 @@
         <translation>Rechercher un texte</translation>
     </message>
     <message>
+        <location filename="window.py" line="125"/>
+        <source>Go to line</source>
+        <translation>Aller à la ligne</translation>
+    </message>
+    <message>
+        <location filename="window.py" line="125"/>
+        <source>Type the line number</source>
+        <translation>Entrer le numéro de ligne</translation>
+    </message>
+    <message>
         <location filename="window.py" line="129"/>
         <source>Preview</source>
         <translation>Aperçu</translation>

--- a/locale/retext_fr.ts
+++ b/locale/retext_fr.ts
@@ -258,16 +258,6 @@
         <translation>Rechercher un texte</translation>
     </message>
     <message>
-        <location filename="window.py" line="125"/>
-        <source>Go to line</source>
-        <translation>Aller à la ligne</translation>
-    </message>
-    <message>
-        <location filename="window.py" line="125"/>
-        <source>Type the line number</source>
-        <translation>Entrer le numéro de ligne</translation>
-    </message>
-    <message>
         <location filename="window.py" line="129"/>
         <source>Preview</source>
         <translation>Aperçu</translation>
@@ -446,6 +436,16 @@
         <location filename="window.py" line="492"/>
         <source>New document</source>
         <translation>Nouveau document</translation>
+    </message>
+    <message>
+        <location filename="window.py" line="657"/>
+        <source>Go to line</source>
+        <translation>Aller à la ligne</translation>
+    </message>
+    <message>
+        <location filename="window.py" line="657"/>
+        <source>Type the line number</source>
+        <translation>Entrer le numéro de ligne</translation>
     </message>
     <message>
         <location filename="window.py" line="664"/>


### PR DESCRIPTION
I used Ctrl-G as a keyboard shortcut, as it was unused before.

I hesitated to open a MessageBox when the document is too short (the line number input is to big), let me know what you think. 