### PR TITLE
Fix Application ID

### DIFF
--- a/data/me.mitya57.ReText.appdata.xml
+++ b/data/me.mitya57.ReText.appdata.xml
@@ -1,7 +1,7 @@
 <!-- Copyright 2018 Dmitry Shachnev -->
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop">
-  <id>me.mitya57.ReText.desktop</id>
+  <id>me.mitya57.ReText</id>
   <name>ReText</name>
   <summary>Simple text editor for Markdown and reStructuredText</summary>
   <summary xml:lang="ca">Editor de Markdown i reStructuredText senzill alhora que potent</summary>


### PR DESCRIPTION
Explanation:
https://github.com/flathub/flathub/wiki/AppData-Guidelines#id

The ID should be the same as the App-Requirements#Application-ID:
```
<!-- Good -->
<id>org.flatpak.qtdemo</id>

<!-- Bad -->
<id>org.flatpak.qtdemo.desktop</id>
<id>qtdemo.desktop</id>

<!-- Incorrect -->
<id>qtdemo</id>
```

See also:

http://docs.flatpak.org/en/latest/conventions.html#application-ids
> As described in Using Flatpak, Flatpak requires each application to have a unique identifier, which has a three-part form such as org.gnome.Dictionary. 

http://docs.flatpak.org/en/latest/using-flatpak.html#identifiers
> Flatpak identifies each application and runtime using a unique three-part identifier, such as com.company.App. The final segment of this address is the object’s name, and the preceding part identifies the developer, so that the same developer can have multiple applications, like com.company.App1 and com.company.App2.