### PR TITLE
Fix #148 - Open documents into new tab rather than new window

### DIFF
--- a/ReText/window.py
+++ b/ReText/window.py
@@ -41,7 +41,7 @@ except ImportError:
 	enchant = None
 
 from PyQt5.QtCore import QDir, QFile, QFileInfo, QFileSystemWatcher, \
- QIODevice, QLocale, QMarginsF, QTextCodec, QTextStream, QTimer, QUrl, Qt
+ QIODevice, QLocale, QMarginsF, QTextCodec, QTextStream, QTimer, QUrl, Qt, pyqtSlot
 from PyQt5.QtGui import QColor, QDesktopServices, QIcon, \
  QKeySequence, QPageLayout, QPageSize, QPagedPaintDevice, QPalette, \
  QTextDocument, QTextDocumentWriter
@@ -826,6 +826,7 @@ class ReTextWindow(QMainWindow):
 		for fileName in fileNames[0]:
 			self.openFileWrapper(fileName)
 
+	@pyqtSlot(str)
 	def openFileWrapper(self, fileName):
 		if not fileName:
 			return


### PR DESCRIPTION
In this way if there is already ReText instance, the second one send the file to the other and kill himself.