### PR TITLE
Fix AppData file

### DIFF
--- a/data/me.mitya57.ReText.appdata.xml
+++ b/data/me.mitya57.ReText.appdata.xml
@@ -1,5 +1,5 @@
-<!-- Copyright 2018 Dmitry Shachnev -->
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2018 Dmitry Shachnev -->
 <component type="desktop">
   <id>me.mitya57.ReText</id>
   <name>ReText</name>
@@ -57,7 +57,7 @@
   <translation type="qt">retext</translation>
   <developer_name>Dmitry Shachnev</developer_name>
   <update_contact>mitya57_AT_gmail.com</update_contact>
-  <content_rating type="oars-1.0" />
+  <content_rating type="oars-1.0"/>
   <releases>
     <release version="7.0.4" date="2018-09-23"/>
     <release version="7.0.3" date="2018-06-06"/>


### PR DESCRIPTION
XML declaration is allowed only at the start of the document.

Some XML tools (e.g. `xmlstarlet`) cannot process the file without this patch.

```
-:2.6: XML declaration allowed only at the start of the document
<?xml version="1.0" encoding="UTF-8"?>
     ^
-:1.1: Document is empty
```