### PR TITLE
Insert an image directly from filesystem

### DIFF
--- a/ReText/editor.py
+++ b/ReText/editor.py
@@ -405,6 +405,16 @@ class ReTextEdit(QTextEdit):
 
 		return chosenFileName, link
 
+	# this function is also accessed in window.insertImage
+	@staticmethod
+	def getCorrectSyntaxLink(markupClass, link):
+		if markupClass == MarkdownMarkup:
+			return '![%s](%s)' % (QFileInfo(link).baseName(), link)
+		elif markupClass == ReStructuredTextMarkup:
+			return '.. image:: %s' % link
+		elif markupClass == TextileMarkup:
+			return '!%s!' % link
+
 	def pasteImage(self):
 		mimeData = QApplication.instance().clipboard().mimeData()
 		fileName, link = self.getImageFilenameAndLink()
@@ -414,12 +424,7 @@ class ReTextEdit(QTextEdit):
 		image.save(fileName)
 
 		markupClass = self.tab.getActiveMarkupClass()
-		if markupClass == MarkdownMarkup:
-			imageText = '![%s](%s)' % (QFileInfo(link).baseName(), link)
-		elif markupClass == ReStructuredTextMarkup:
-			imageText = '.. image:: %s' % link
-		elif markupClass == TextileMarkup:
-			imageText = '!%s!' % link
+		imageText = self.getCorrectSyntaxLink(markupClass, link)
 
 		self.textCursor().insertText(imageText)
 

--- a/ReText/editor.py
+++ b/ReText/editor.py
@@ -405,9 +405,12 @@ class ReTextEdit(QTextEdit):
 
 		return chosenFileName, link
 
-	# this function is also accessed in window.insertImage
-	@staticmethod
-	def getCorrectSyntaxLink(markupClass, link):
+	def getImageMarkup(self, link):
+		"""Returns markup for image in the current markup language.
+
+		This method is also accessed in ReTextWindow.insertImage.
+		"""
+		markupClass = self.tab.getActiveMarkupClass()
 		if markupClass == MarkdownMarkup:
 			return '![%s](%s)' % (QFileInfo(link).baseName(), link)
 		elif markupClass == ReStructuredTextMarkup:
@@ -423,8 +426,7 @@ class ReTextEdit(QTextEdit):
 		image = QImage(mimeData.imageData())
 		image.save(fileName)
 
-		markupClass = self.tab.getActiveMarkupClass()
-		imageText = self.getCorrectSyntaxLink(markupClass, link)
+		imageText = self.getImageMarkup(link)
 
 		self.textCursor().insertText(imageText)
 

--- a/ReText/editor.py
+++ b/ReText/editor.py
@@ -378,7 +378,7 @@ class ReTextEdit(QTextEdit):
 				highestNumber = max(number, highestNumber)
 		return 'image%04d.png' % (highestNumber + 1)
 
-	def getImageFilenameAndLink(self):
+	def getImageFilename(self):
 		if self.tab.fileName:
 			saveDir = os.path.dirname(self.tab.fileName)
 		else:
@@ -386,30 +386,30 @@ class ReTextEdit(QTextEdit):
 
 		imageFileName = self.findNextImageName(os.listdir(saveDir))
 
-		chosenFileName = QFileDialog.getSaveFileName(self,
+		return QFileDialog.getSaveFileName(self,
 		                                   self.tr('Save image'),
 		                                   os.path.join(saveDir, imageFileName),
 		                                   self.tr('Images (*.png *.jpg)'))[0]
 
-		if chosenFileName:
-			# Use relative links for named documents
-			if self.tab.fileName:
-				try:
-					link = os.path.relpath(chosenFileName, saveDir)
-				except ValueError:  # different roots
-					link = chosenFileName
-			else:
-				link = chosenFileName
-		else:
-			link = None
+	def makeFileNameRelative(self, fileName):
+		"""Tries to make the given fileName relative. If the document is
+		not saved, or the fileName is on a different root, returns the
+		original fileName.
+		"""
+		if self.tab.fileName:
+			currentDir = os.path.dirname(self.tab.fileName)
+			try:
+				return os.path.relpath(fileName, currentDir)
+			except ValueError:  # different roots
+				return fileName
+		return fileName
 
-		return chosenFileName, link
-
-	def getImageMarkup(self, link):
+	def getImageMarkup(self, fileName):
 		"""Returns markup for image in the current markup language.
 
 		This method is also accessed in ReTextWindow.insertImage.
 		"""
+		link = self.makeFileNameRelative(fileName)
 		markupClass = self.tab.getActiveMarkupClass()
 		if markupClass == MarkdownMarkup:
 			return '![%s](%s)' % (QFileInfo(link).baseName(), link)
@@ -420,13 +420,13 @@ class ReTextEdit(QTextEdit):
 
 	def pasteImage(self):
 		mimeData = QApplication.instance().clipboard().mimeData()
-		fileName, link = self.getImageFilenameAndLink()
+		fileName = self.getImageFilename()
 		if not fileName or not mimeData.hasImage():
 			return
 		image = QImage(mimeData.imageData())
 		image.save(fileName)
 
-		imageText = self.getImageMarkup(link)
+		imageText = self.getImageMarkup(fileName)
 
 		self.textCursor().insertText(imageText)
 

--- a/ReText/window.py
+++ b/ReText/window.py
@@ -1254,11 +1254,10 @@ class ReTextWindow(QMainWindow):
 
 		cursor = self.currentTab.editBox.textCursor()
 
-		# if there're more than one file, add break lines '\n'
-		bl = '\n' if len(fileNames) > 1 else ''
-		for fileName in fileNames:
-			imageMarkup = self.currentTab.editBox.getImageMarkup(fileName)
-			cursor.insertText(imageMarkup + bl)
+		imagesMarkup = '\n'.join(
+			self.currentTab.editBox.getImageMarkup(fileName)
+			for fileName in fileNames)
+		cursor.insertText(imagesMarkup)
 
 		self.formattingBox.setCurrentIndex(0)
 		self.currentTab.editBox.setFocus(Qt.OtherFocusReason)

--- a/ReText/window.py
+++ b/ReText/window.py
@@ -1248,15 +1248,17 @@ class ReTextWindow(QMainWindow):
 	def insertImage(self):
 		supportedExtensions = ['.png', '.jpg', '.jpeg', '.gif', '.bmp']
 		fileFilter = ' (' + str.join(' ', ['*' + ext for ext in supportedExtensions]) + ');;'
-		fileName = QFileDialog.getOpenFileName(self,
-			self.tr("Select one or several files to open"), QDir.currentPath(),
+		fileNames = QFileDialog.getOpenFileNames(self,
+			self.tr("Select one or several images to open"), QDir.currentPath(),
 			self.tr("Supported files") + fileFilter + self.tr("All files (*)"))
 
-		fileName = fileName[0]
-		imageText = '![{0}]({1})'.format(self.tr('Alt text'), self.tr(fileName))
-
 		cursor = self.currentTab.editBox.textCursor()
-		cursor.insertText(imageText)
+		# if there're more than one file, add break lines '\n'
+		bl = '\n' if len(fileNames[0]) > 1 else ''
+		for fileName in fileNames[0]:
+			imageText = '![{0}]({1}){2}'.format(self.tr('Alt text'), self.tr(fileName), bl)
+			cursor.insertText(imageText)
+
 		self.formattingBox.setCurrentIndex(0)
 		self.currentTab.editBox.setFocus(Qt.OtherFocusReason)
 

--- a/ReText/window.py
+++ b/ReText/window.py
@@ -146,6 +146,8 @@ class ReTextWindow(QMainWindow):
 		self.actionTableMode = self.act(self.tr('Table editing mode'),
 			shct=Qt.CTRL+Qt.Key_T,
 			trigbool=lambda x: self.currentTab.editBox.enableTableMode(x))
+		self.actionInsertImage = self.act(self.tr('Insert images by file path'),
+			trig=lambda: self.insertFormatting('image'))
 		if ReTextFakeVimHandler:
 			self.actionFakeVimMode = self.act(self.tr('FakeVim mode'),
 				shct=Qt.CTRL+Qt.ALT+Qt.Key_V, trigbool=self.enableFakeVimMode)
@@ -326,6 +328,7 @@ class ReTextWindow(QMainWindow):
 		menuEdit.addAction(self.actionPreview)
 		menuEdit.addAction(self.actionInsertTable)
 		menuEdit.addAction(self.actionTableMode)
+		menuEdit.addAction(self.actionInsertImage)
 		if ReTextFakeVimHandler:
 			menuEdit.addAction(self.actionFakeVimMode)
 		menuEdit.addSeparator()

--- a/ReText/window.py
+++ b/ReText/window.py
@@ -148,7 +148,7 @@ class ReTextWindow(QMainWindow):
 			shct=Qt.CTRL+Qt.Key_T,
 			trigbool=lambda x: self.currentTab.editBox.enableTableMode(x))
 		self.actionInsertImage = self.act(self.tr('Insert images by file path'),
-			trig=lambda: self.insertFormatting('image'))
+			trig=lambda: self.insertImage())
 		if ReTextFakeVimHandler:
 			self.actionFakeVimMode = self.act(self.tr('FakeVim mode'),
 				shct=Qt.CTRL+Qt.ALT+Qt.Key_V, trigbool=self.enableFakeVimMode)

--- a/ReText/window.py
+++ b/ReText/window.py
@@ -28,6 +28,7 @@ from ReText.tab import (ReTextTab, ReTextWebKitPreview, ReTextWebEnginePreview,
 from ReText.dialogs import HtmlDialog, LocaleDialog
 from ReText.config import ConfigDialog, setIconThemeFromSettings
 from ReText.tabledialog import InsertTableDialog
+from ReText.editor import ReTextEdit
 
 try:
 	from ReText.fakevimeditor import ReTextFakeVimHandler, FakeVimMode
@@ -1253,11 +1254,13 @@ class ReTextWindow(QMainWindow):
 			self.tr("Supported files") + fileFilter + self.tr("All files (*)"))
 
 		cursor = self.currentTab.editBox.textCursor()
+		markupClass = self.currentTab.getActiveMarkupClass()
+
 		# if there're more than one file, add break lines '\n'
 		bl = '\n' if len(fileNames[0]) > 1 else ''
 		for fileName in fileNames[0]:
-			imageText = '![{0}]({1}){2}'.format(self.tr('Alt text'), self.tr(fileName), bl)
-			cursor.insertText(imageText)
+			imageText = ReTextEdit.getCorrectSyntaxLink(markupClass, fileName)
+			cursor.insertText(imageText + bl)
 
 		self.formattingBox.setCurrentIndex(0)
 		self.currentTab.editBox.setFocus(Qt.OtherFocusReason)

--- a/ReText/window.py
+++ b/ReText/window.py
@@ -1105,6 +1105,9 @@ class ReTextWindow(QMainWindow):
 			dialog.show()
 			self.formattingBox.setCurrentIndex(0)
 			return
+		elif formatting == 'image':
+			self.insertImage()
+			return
 
 		cursor = self.currentTab.editBox.textCursor()
 		text = cursor.selectedText()
@@ -1238,6 +1241,21 @@ class ReTextWindow(QMainWindow):
 		htmlDlg.show()
 		htmlDlg.raise_()
 		htmlDlg.activateWindow()
+
+	def insertImage(self):
+		supportedExtensions = ['.png', '.jpg', '.jpeg', '.gif', '.bmp']
+		fileFilter = ' (' + str.join(' ', ['*' + ext for ext in supportedExtensions]) + ');;'
+		fileName = QFileDialog.getOpenFileName(self,
+												 self.tr("Select one or several files to open"), QDir.currentPath(),
+												 self.tr("Supported files") + fileFilter + self.tr("All files (*)"))
+
+		fileName = fileName[0]
+		imageText = '![{0}]({1})'.format(self.tr('Alt text'), self.tr(fileName))
+
+		cursor = self.currentTab.editBox.textCursor()
+		cursor.insertText(imageText)
+		self.formattingBox.setCurrentIndex(0)
+		self.currentTab.editBox.setFocus(Qt.OtherFocusReason)
 
 	def openHelp(self):
 		QDesktopServices.openUrl(QUrl('https://github.com/retext-project/retext/wiki'))

--- a/ReText/window.py
+++ b/ReText/window.py
@@ -146,8 +146,8 @@ class ReTextWindow(QMainWindow):
 		self.actionTableMode = self.act(self.tr('Table editing mode'),
 			shct=Qt.CTRL+Qt.Key_T,
 			trigbool=lambda x: self.currentTab.editBox.enableTableMode(x))
-		self.actionInsertImage = self.act(self.tr('Insert images by file path'),
-			trig=lambda: self.insertImage())
+		self.actionInsertImages = self.act(self.tr('Insert images by file path'),
+			trig=lambda: self.insertImages())
 		if ReTextFakeVimHandler:
 			self.actionFakeVimMode = self.act(self.tr('FakeVim mode'),
 				shct=Qt.CTRL+Qt.ALT+Qt.Key_V, trigbool=self.enableFakeVimMode)
@@ -328,7 +328,7 @@ class ReTextWindow(QMainWindow):
 		menuEdit.addAction(self.actionPreview)
 		menuEdit.addAction(self.actionInsertTable)
 		menuEdit.addAction(self.actionTableMode)
-		menuEdit.addAction(self.actionInsertImage)
+		menuEdit.addAction(self.actionInsertImages)
 		if ReTextFakeVimHandler:
 			menuEdit.addAction(self.actionFakeVimMode)
 		menuEdit.addSeparator()
@@ -1242,7 +1242,7 @@ class ReTextWindow(QMainWindow):
 		htmlDlg.raise_()
 		htmlDlg.activateWindow()
 
-	def insertImage(self):
+	def insertImages(self):
 		supportedExtensions = ['.png', '.jpg', '.jpeg', '.gif', '.bmp']
 		fileFilter = ' (%s);;' % ' '.join('*' + ext for ext in supportedExtensions)
 		fileNames, _selectedFilter = QFileDialog.getOpenFileNames(self,

--- a/ReText/window.py
+++ b/ReText/window.py
@@ -1248,15 +1248,15 @@ class ReTextWindow(QMainWindow):
 	def insertImage(self):
 		supportedExtensions = ['.png', '.jpg', '.jpeg', '.gif', '.bmp']
 		fileFilter = ' (' + str.join(' ', ['*' + ext for ext in supportedExtensions]) + ');;'
-		fileNames = QFileDialog.getOpenFileNames(self,
+		fileNames, _selectedFilter = QFileDialog.getOpenFileNames(self,
 			self.tr("Select one or several images to open"), QDir.currentPath(),
 			self.tr("Supported files") + fileFilter + self.tr("All files (*)"))
 
 		cursor = self.currentTab.editBox.textCursor()
 
 		# if there're more than one file, add break lines '\n'
-		bl = '\n' if len(fileNames[0]) > 1 else ''
-		for fileName in fileNames[0]:
+		bl = '\n' if len(fileNames) > 1 else ''
+		for fileName in fileNames:
 			imageMarkup = self.currentTab.editBox.getImageMarkup(fileName)
 			cursor.insertText(imageMarkup + bl)
 

--- a/ReText/window.py
+++ b/ReText/window.py
@@ -1108,9 +1108,6 @@ class ReTextWindow(QMainWindow):
 			dialog.show()
 			self.formattingBox.setCurrentIndex(0)
 			return
-		elif formatting == 'image':
-			self.insertImage()
-			return
 
 		cursor = self.currentTab.editBox.textCursor()
 		text = cursor.selectedText()

--- a/ReText/window.py
+++ b/ReText/window.py
@@ -141,7 +141,7 @@ class ReTextWindow(QMainWindow):
 		menuPreview = QMenu()
 		menuPreview.addAction(self.actionLivePreview)
 		self.actionPreview.setMenu(menuPreview)
-		self.actionInsertTable = self.act(self.tr('Table'),
+		self.actionInsertTable = self.act(self.tr('Insert table'),
 			trig=lambda: self.insertFormatting('table'))
 		self.actionTableMode = self.act(self.tr('Table editing mode'),
 			shct=Qt.CTRL+Qt.Key_T,
@@ -217,8 +217,6 @@ class ReTextWindow(QMainWindow):
 			lambda: self.searchBar.setVisible(False),
 			shct=QKeySequence.Cancel)
 		self.actionCloseSearch.setPriority(QAction.LowPriority)
-		self.actionInsertImage = self.act(self.tr('Image'), 'image',
-										  self.insertImage)
 		self.actionHelp = self.act(self.tr('Get help online'), 'help-contents', self.openHelp)
 		self.aboutWindowTitle = self.tr('About ReText')
 		self.actionAbout = self.act(self.aboutWindowTitle, 'help-about', self.aboutDialog)
@@ -262,7 +260,6 @@ class ReTextWindow(QMainWindow):
 		menubar = self.menuBar()
 		menuFile = menubar.addMenu(self.tr('File'))
 		menuEdit = menubar.addMenu(self.tr('Edit'))
-		menuInsert = menubar.addMenu(self.tr('Insert'))
 		menuHelp = menubar.addMenu(self.tr('Help'))
 		menuFile.addAction(self.actionNew)
 		menuFile.addAction(self.actionOpen)
@@ -327,15 +324,13 @@ class ReTextWindow(QMainWindow):
 		menuEdit.addSeparator()
 		menuEdit.addAction(self.actionViewHtml)
 		menuEdit.addAction(self.actionPreview)
+		menuEdit.addAction(self.actionInsertTable)
+		menuEdit.addAction(self.actionTableMode)
 		if ReTextFakeVimHandler:
 			menuEdit.addAction(self.actionFakeVimMode)
 		menuEdit.addSeparator()
 		menuEdit.addAction(self.actionFullScreen)
 		menuEdit.addAction(self.actionConfig)
-		menuInsert.addAction(self.actionInsertTable)
-		menuInsert.addAction(self.actionTableMode)
-		menuInsert.addSeparator()
-		menuInsert.addAction(self.actionInsertImage)
 		menuHelp.addAction(self.actionHelp)
 		menuHelp.addSeparator()
 		menuHelp.addAction(self.actionAbout)

--- a/ReText/window.py
+++ b/ReText/window.py
@@ -28,7 +28,6 @@ from ReText.tab import (ReTextTab, ReTextWebKitPreview, ReTextWebEnginePreview,
 from ReText.dialogs import HtmlDialog, LocaleDialog
 from ReText.config import ConfigDialog, setIconThemeFromSettings
 from ReText.tabledialog import InsertTableDialog
-from ReText.editor import ReTextEdit
 
 try:
 	from ReText.fakevimeditor import ReTextFakeVimHandler, FakeVimMode
@@ -1254,13 +1253,12 @@ class ReTextWindow(QMainWindow):
 			self.tr("Supported files") + fileFilter + self.tr("All files (*)"))
 
 		cursor = self.currentTab.editBox.textCursor()
-		markupClass = self.currentTab.getActiveMarkupClass()
 
 		# if there're more than one file, add break lines '\n'
 		bl = '\n' if len(fileNames[0]) > 1 else ''
 		for fileName in fileNames[0]:
-			imageText = ReTextEdit.getCorrectSyntaxLink(markupClass, fileName)
-			cursor.insertText(imageText + bl)
+			imageMarkup = self.currentTab.editBox.getImageMarkup(fileName)
+			cursor.insertText(imageMarkup + bl)
 
 		self.formattingBox.setCurrentIndex(0)
 		self.currentTab.editBox.setFocus(Qt.OtherFocusReason)

--- a/ReText/window.py
+++ b/ReText/window.py
@@ -141,7 +141,7 @@ class ReTextWindow(QMainWindow):
 		menuPreview = QMenu()
 		menuPreview.addAction(self.actionLivePreview)
 		self.actionPreview.setMenu(menuPreview)
-		self.actionInsertTable = self.act(self.tr('Insert table'),
+		self.actionInsertTable = self.act(self.tr('Table'),
 			trig=lambda: self.insertFormatting('table'))
 		self.actionTableMode = self.act(self.tr('Table editing mode'),
 			shct=Qt.CTRL+Qt.Key_T,
@@ -217,6 +217,8 @@ class ReTextWindow(QMainWindow):
 			lambda: self.searchBar.setVisible(False),
 			shct=QKeySequence.Cancel)
 		self.actionCloseSearch.setPriority(QAction.LowPriority)
+		self.actionInsertImage = self.act(self.tr('Image'), 'image',
+										  self.insertImage)
 		self.actionHelp = self.act(self.tr('Get help online'), 'help-contents', self.openHelp)
 		self.aboutWindowTitle = self.tr('About ReText')
 		self.actionAbout = self.act(self.aboutWindowTitle, 'help-about', self.aboutDialog)
@@ -260,6 +262,7 @@ class ReTextWindow(QMainWindow):
 		menubar = self.menuBar()
 		menuFile = menubar.addMenu(self.tr('File'))
 		menuEdit = menubar.addMenu(self.tr('Edit'))
+		menuInsert = menubar.addMenu(self.tr('Insert'))
 		menuHelp = menubar.addMenu(self.tr('Help'))
 		menuFile.addAction(self.actionNew)
 		menuFile.addAction(self.actionOpen)
@@ -324,13 +327,15 @@ class ReTextWindow(QMainWindow):
 		menuEdit.addSeparator()
 		menuEdit.addAction(self.actionViewHtml)
 		menuEdit.addAction(self.actionPreview)
-		menuEdit.addAction(self.actionInsertTable)
-		menuEdit.addAction(self.actionTableMode)
 		if ReTextFakeVimHandler:
 			menuEdit.addAction(self.actionFakeVimMode)
 		menuEdit.addSeparator()
 		menuEdit.addAction(self.actionFullScreen)
 		menuEdit.addAction(self.actionConfig)
+		menuInsert.addAction(self.actionInsertTable)
+		menuInsert.addAction(self.actionTableMode)
+		menuInsert.addSeparator()
+		menuInsert.addAction(self.actionInsertImage)
 		menuHelp.addAction(self.actionHelp)
 		menuHelp.addSeparator()
 		menuHelp.addAction(self.actionAbout)

--- a/ReText/window.py
+++ b/ReText/window.py
@@ -1247,7 +1247,7 @@ class ReTextWindow(QMainWindow):
 
 	def insertImage(self):
 		supportedExtensions = ['.png', '.jpg', '.jpeg', '.gif', '.bmp']
-		fileFilter = ' (' + str.join(' ', ['*' + ext for ext in supportedExtensions]) + ');;'
+		fileFilter = ' (%s);;' % ' '.join('*' + ext for ext in supportedExtensions)
 		fileNames, _selectedFilter = QFileDialog.getOpenFileNames(self,
 			self.tr("Select one or several images to open"), QDir.currentPath(),
 			self.tr("Supported files") + fileFilter + self.tr("All files (*)"))

--- a/ReText/window.py
+++ b/ReText/window.py
@@ -1246,8 +1246,8 @@ class ReTextWindow(QMainWindow):
 		supportedExtensions = ['.png', '.jpg', '.jpeg', '.gif', '.bmp']
 		fileFilter = ' (' + str.join(' ', ['*' + ext for ext in supportedExtensions]) + ');;'
 		fileName = QFileDialog.getOpenFileName(self,
-												 self.tr("Select one or several files to open"), QDir.currentPath(),
-												 self.tr("Supported files") + fileFilter + self.tr("All files (*)"))
+			self.tr("Select one or several files to open"), QDir.currentPath(),
+			self.tr("Supported files") + fileFilter + self.tr("All files (*)"))
 
 		fileName = fileName[0]
 		imageText = '![{0}]({1})'.format(self.tr('Alt text'), self.tr(fileName))

--- a/tests/test_editor.py
+++ b/tests/test_editor.py
@@ -111,24 +111,26 @@ class TestClipboardHandling(unittest.TestCase):
 		self.editor.insertFromMimeData(mimeData)
 		self.assertTrue('pasted text' in self.editor.toPlainText())
 
-	@patch.object(ReTextEdit, 'getImageFilenameAndLink', return_value=('/tmp/myimage.jpg', 'myimage.jpg'))
+	@patch.object(ReTextEdit, 'getImageFilename', return_value='/tmp/myimage.jpg')
 	@patch.object(QImage, 'save')
 	def test_pasteImage_Markdown(self, _mock_image, _mock_editor):
 		mimeData = QMimeData()
 		mimeData.setImageData(self._create_image())
 		app.clipboard().setMimeData(mimeData)
 		self.dummytab.markupClass = MarkdownMarkup
+		self.dummytab.fileName = '/tmp/foo.md'
 
 		self.editor.pasteImage()
 		self.assertTrue('![myimage](myimage.jpg)' in self.editor.toPlainText())
 
-	@patch.object(ReTextEdit, 'getImageFilenameAndLink', return_value=('/tmp/myimage.jpg', 'myimage.jpg'))
+	@patch.object(ReTextEdit, 'getImageFilename', return_value='/tmp/myimage.jpg')
 	@patch.object(QImage, 'save')
 	def test_pasteImage_RestructuredText(self, _mock_image, _mock_editor):
 		mimeData = QMimeData()
 		mimeData.setImageData(self._create_image())
 		app.clipboard().setMimeData(mimeData)
 		self.dummytab.markupClass = ReStructuredTextMarkup
+		self.dummytab.fileName = '/tmp/foo.rst'
 
 		self.editor.pasteImage()
 		self.assertTrue('.. image:: myimage.jpg' in self.editor.toPlainText())


### PR DESCRIPTION
Hello, nice software.

I guess the retex would be great if it allows insert image directly by filesystem. The first commit allows to open a select box and get the image path, that is, selecting an image results in:
`![Alt text](/home/user/path/to/image.png)`.

The second commit create a menu bar called **Insert** with the *Tables* and *Image* as sub-menus, where *Image* uses the function written at first commit. The *Tables* sub-menus (*Insert table* and *Table editing mode*) were in **Edit** menu, and it doesn't make much sense, I guess. Then, I removed those and inserted in **Insert** menu.