### PR TITLE
Add surround keys

### DIFF
--- a/tests/test_editor.py
+++ b/tests/test_editor.py
@@ -169,7 +169,6 @@ class TestSurround(unittest.TestCase):
 		self.assertTrue(self.editor.isSurroundKey(Qt.Key_Apostrophe))
 
 	def test_getCloseKey(self):
-		# xvfb-run -a -s "-screen 0 1024x768x24" python3 setup.py test
 		self.assertEqual(self.editor.getCloseKey(self.getEvent(Qt.Key_Underscore), Qt.Key_Underscore), '_')
 		self.assertEqual(self.editor.getCloseKey(self.getEvent(Qt.Key_Asterisk), Qt.Key_Asterisk), '*')
 		self.assertEqual(self.editor.getCloseKey(self.getEvent(Qt.Key_QuoteDbl), Qt.Key_QuoteDbl), '"')


### PR DESCRIPTION
Hi, nice app.

This pull add a functionality that surrounds a selected text with a special key rather than replace it.

e.g.:
"This text is in editor now" -> select `text` and press `(` -> "This (text) is in editor now"
"This text is in editor now" -> select `text` and press `_` -> "This \_text\_ is in editor now"
"This text is in editor now" -> select `text` and press `'` -> "This 'text' is in editor now"

It works as expected for the follow keys: `*`, `_`, `"`, `'`, `(`, `[`