### PR TITLE
Fix #516: Option to fully highlight wrapped-lines

### DIFF
--- a/ReText/__init__.py
+++ b/ReText/__init__.py
@@ -76,7 +76,7 @@ configOptions = {
 	'font': QFont(),
 	'handleWebLinks': False,
 	'hideToolBar': False,
-	'highlightCurrentLine': False,
+	'highlightCurrentLine': 'disabled',
 	'iconTheme': '',
 	'lastTabIndex': 0,
 	'lineNumbersEnabled': False,

--- a/ReText/config.py
+++ b/ReText/config.py
@@ -171,6 +171,13 @@ class ConfigDialog(QDialog):
 				self.configurators[name].addItem(self.tr('Normal preview'), 'normal-preview')
 				comboBoxIndex = self.configurators[name].findData(value)
 				self.configurators[name].setCurrentIndex(comboBoxIndex)
+			elif name == 'highlightCurrentLine':
+				self.configurators[name] = QComboBox(self)
+				self.configurators[name].addItem(self.tr('Disabled'), 'disabled')
+				self.configurators[name].addItem(self.tr('Cursor Line'), 'cursor-line')
+				self.configurators[name].addItem(self.tr('Wrapped Line'), 'wrapped-line')
+				comboBoxIndex = self.configurators[name].findData(value)
+				self.configurators[name].setCurrentIndex(comboBoxIndex)
 			elif isinstance(value, bool):
 				self.configurators[name] = QCheckBox(self)
 				self.configurators[name].setChecked(value)

--- a/ReText/editor.py
+++ b/ReText/editor.py
@@ -373,25 +373,21 @@ class ReTextEdit(QTextEdit):
 		if globalSettings.highlightCurrentLine == 'disabled':
 			return self.setExtraSelections([])
 		elif globalSettings.highlightCurrentLine == 'cursor-line':
-			selection = QTextEdit.ExtraSelection();
+			selection = QTextEdit.ExtraSelection()
 			selection.format.setBackground(colorValues['currentLineHighlight'])
 			selection.format.setProperty(QTextFormat.FullWidthSelection, True)
 			selection.cursor = self.textCursor()
 			selection.cursor.clearSelection()
 			self.setExtraSelections([selection])
 		elif globalSettings.highlightCurrentLine == 'wrapped-line':
-			selections = [QTextEdit.ExtraSelection(),QTextEdit.ExtraSelection()]
-			selections[0].format.setBackground(colorValues['currentLineHighlight'])
-			selections[0].format.setProperty(QTextFormat.FullWidthSelection, True)
-			selections[0].cursor = self.textCursor()
-			selections[0].cursor.clearSelection()
-			selections[0].cursor.movePosition(QTextCursor.StartOfBlock)
-			selections[0].cursor.movePosition(QTextCursor.EndOfBlock, QTextCursor.KeepAnchor)
-			selections[1].format.setBackground(colorValues['currentLineHighlight'])
-			selections[1].format.setProperty(QTextFormat.FullWidthSelection, True)
-			selections[1].cursor = self.textCursor()
-			selections[1].cursor.movePosition(QTextCursor.EndOfBlock)
-			self.setExtraSelections(selections)
+			selection = QTextEdit.ExtraSelection()
+			selection.format.setBackground(colorValues['currentLineHighlight'])
+			selection.format.setProperty(QTextFormat.FullWidthSelection, True)
+			selection.cursor = self.textCursor()
+			selection.cursor.clearSelection()
+			selection.cursor.movePosition(QTextCursor.StartOfBlock)
+			selection.cursor.movePosition(QTextCursor.EndOfBlock+1, QTextCursor.KeepAnchor)
+			self.setExtraSelections([selection])
 
 	def enableTableMode(self, enable):
 		self.tableModeEnabled = enable

--- a/ReText/editor.py
+++ b/ReText/editor.py
@@ -370,14 +370,28 @@ class ReTextEdit(QTextEdit):
 	def highlightCurrentLine(self):
 		if globalSettings.relativeLineNumbers:
 			self.lineNumberArea.update()
-		if not globalSettings.highlightCurrentLine:
+		if globalSettings.highlightCurrentLine == 'disabled':
 			return self.setExtraSelections([])
-		selection = QTextEdit.ExtraSelection();
-		selection.format.setBackground(colorValues['currentLineHighlight'])
-		selection.format.setProperty(QTextFormat.FullWidthSelection, True)
-		selection.cursor = self.textCursor()
-		selection.cursor.clearSelection()
-		self.setExtraSelections([selection])
+		elif globalSettings.highlightCurrentLine == 'cursor-line':
+			selection = QTextEdit.ExtraSelection();
+			selection.format.setBackground(colorValues['currentLineHighlight'])
+			selection.format.setProperty(QTextFormat.FullWidthSelection, True)
+			selection.cursor = self.textCursor()
+			selection.cursor.clearSelection()
+			self.setExtraSelections([selection])
+		elif globalSettings.highlightCurrentLine == 'wrapped-line':
+			selections = [QTextEdit.ExtraSelection(),QTextEdit.ExtraSelection()]
+			selections[0].format.setBackground(colorValues['currentLineHighlight'])
+			selections[0].format.setProperty(QTextFormat.FullWidthSelection, True)
+			selections[0].cursor = self.textCursor()
+			selections[0].cursor.clearSelection()
+			selections[0].cursor.movePosition(QTextCursor.StartOfBlock)
+			selections[0].cursor.movePosition(QTextCursor.EndOfBlock, QTextCursor.KeepAnchor)
+			selections[1].format.setBackground(colorValues['currentLineHighlight'])
+			selections[1].format.setProperty(QTextFormat.FullWidthSelection, True)
+			selections[1].cursor = self.textCursor()
+			selections[1].cursor.movePosition(QTextCursor.EndOfBlock)
+			self.setExtraSelections(selections)
 
 	def enableTableMode(self, enable):
 		self.tableModeEnabled = enable

--- a/ReText/editor.py
+++ b/ReText/editor.py
@@ -372,22 +372,21 @@ class ReTextEdit(QTextEdit):
 			self.lineNumberArea.update()
 		if globalSettings.highlightCurrentLine == 'disabled':
 			return self.setExtraSelections([])
-		else:
-			selection = QTextEdit.ExtraSelection()
-			selection.format.setBackground(colorValues['currentLineHighlight'])
-			selection.format.setProperty(QTextFormat.FullWidthSelection, True)
-			selection.cursor = self.textCursor()
-			selection.cursor.clearSelection()
-			selections = [selection]
-			if globalSettings.highlightCurrentLine == 'wrapped-line':
-				selections.append(QTextEdit.ExtraSelection())
-				selections[0].cursor.movePosition(QTextCursor.StartOfBlock)
-				selections[0].cursor.movePosition(QTextCursor.EndOfBlock, QTextCursor.KeepAnchor)
-				selections[1].format.setBackground(colorValues['currentLineHighlight'])
-				selections[1].format.setProperty(QTextFormat.FullWidthSelection, True)
-				selections[1].cursor = self.textCursor()
-				selections[1].cursor.movePosition(QTextCursor.EndOfBlock)
-			self.setExtraSelections(selections)
+		selection = QTextEdit.ExtraSelection()
+		selection.format.setBackground(colorValues['currentLineHighlight'])
+		selection.format.setProperty(QTextFormat.FullWidthSelection, True)
+		selection.cursor = self.textCursor()
+		selection.cursor.clearSelection()
+		selections = [selection]
+		if globalSettings.highlightCurrentLine == 'wrapped-line':
+			selections.append(QTextEdit.ExtraSelection())
+			selections[0].cursor.movePosition(QTextCursor.StartOfBlock)
+			selections[0].cursor.movePosition(QTextCursor.EndOfBlock, QTextCursor.KeepAnchor)
+			selections[1].format.setBackground(colorValues['currentLineHighlight'])
+			selections[1].format.setProperty(QTextFormat.FullWidthSelection, True)
+			selections[1].cursor = self.textCursor()
+			selections[1].cursor.movePosition(QTextCursor.EndOfBlock)
+		self.setExtraSelections(selections)
 
 	def enableTableMode(self, enable):
 		self.tableModeEnabled = enable

--- a/ReText/editor.py
+++ b/ReText/editor.py
@@ -372,22 +372,22 @@ class ReTextEdit(QTextEdit):
 			self.lineNumberArea.update()
 		if globalSettings.highlightCurrentLine == 'disabled':
 			return self.setExtraSelections([])
-		elif globalSettings.highlightCurrentLine == 'cursor-line':
+		else:
 			selection = QTextEdit.ExtraSelection()
 			selection.format.setBackground(colorValues['currentLineHighlight'])
 			selection.format.setProperty(QTextFormat.FullWidthSelection, True)
 			selection.cursor = self.textCursor()
 			selection.cursor.clearSelection()
-			self.setExtraSelections([selection])
-		elif globalSettings.highlightCurrentLine == 'wrapped-line':
-			selection = QTextEdit.ExtraSelection()
-			selection.format.setBackground(colorValues['currentLineHighlight'])
-			selection.format.setProperty(QTextFormat.FullWidthSelection, True)
-			selection.cursor = self.textCursor()
-			selection.cursor.clearSelection()
-			selection.cursor.movePosition(QTextCursor.StartOfBlock)
-			selection.cursor.movePosition(QTextCursor.EndOfBlock+1, QTextCursor.KeepAnchor)
-			self.setExtraSelections([selection])
+			selections = [selection]
+			if globalSettings.highlightCurrentLine == 'wrapped-line':
+				selections.append(QTextEdit.ExtraSelection())
+				selections[0].cursor.movePosition(QTextCursor.StartOfBlock)
+				selections[0].cursor.movePosition(QTextCursor.EndOfBlock, QTextCursor.KeepAnchor)
+				selections[1].format.setBackground(colorValues['currentLineHighlight'])
+				selections[1].format.setProperty(QTextFormat.FullWidthSelection, True)
+				selections[1].cursor = self.textCursor()
+				selections[1].cursor.movePosition(QTextCursor.EndOfBlock)
+			self.setExtraSelections(selections)
 
 	def enableTableMode(self, enable):
 		self.tableModeEnabled = enable


### PR DESCRIPTION
As stated in the title, this will resolve #516, giving the option to fully highlight the wrapped-line under the cursor, or only the single line under the cursor (current behaviour).