### PR TITLE
Ordered list behavior can now be configured to repeat or increment the list item number

### DIFF
--- a/ReText/__init__.py
+++ b/ReText/__init__.py
@@ -83,6 +83,7 @@ configOptions = {
 	'markdownDefaultFileExtension': '.mkd',
 	'openFilesInExistingWindow': True,
 	'openLastFilesOnStartup': False,
+	'orderedListMode': 'increment',
 	'paperSize': '',
 	'pygmentsStyle': 'default',
 	'recentDocumentsCount': 10,

--- a/ReText/config.py
+++ b/ReText/config.py
@@ -117,6 +117,7 @@ class ConfigDialog(QDialog):
 				(self.tr('Draw vertical line at column'), 'rightMargin'),
 				(self.tr('Enable soft wrap'), 'rightMarginWrap'),
 				(self.tr('Show document stats'), 'documentStatsEnabled'),
+				(self.tr('Ordered list mode'), 'orderedListMode'),
 			)),
 			(self.tr('Interface'), (
 				(self.tr('Hide toolbar'), 'hideToolBar'),
@@ -176,6 +177,12 @@ class ConfigDialog(QDialog):
 				self.configurators[name].addItem(self.tr('Disabled'), 'disabled')
 				self.configurators[name].addItem(self.tr('Cursor Line'), 'cursor-line')
 				self.configurators[name].addItem(self.tr('Wrapped Line'), 'wrapped-line')
+				comboBoxIndex = self.configurators[name].findData(value)
+				self.configurators[name].setCurrentIndex(comboBoxIndex)
+			elif name == 'orderedListMode':
+				self.configurators[name] = QComboBox(self)
+				self.configurators[name].addItem(self.tr('Increment'), 'increment')
+				self.configurators[name].addItem(self.tr('Repeat'), 'repeat')
 				comboBoxIndex = self.configurators[name].findData(value)
 				self.configurators[name].setCurrentIndex(comboBoxIndex)
 			elif isinstance(value, bool):

--- a/ReText/editor.py
+++ b/ReText/editor.py
@@ -108,7 +108,7 @@ class ReTextEdit(QTextEdit):
 		Qt.Key_BracketLeft: ']'
 	}
 
-	def __init__(self, parent):
+	def __init__(self, parent, settings=globalSettings):
 		QTextEdit.__init__(self)
 		self.tab = weakref.proxy(parent)
 		self.parent = parent.p
@@ -124,6 +124,7 @@ class ReTextEdit(QTextEdit):
 		self.document().blockCountChanged.connect(self.updateLineNumberAreaWidth)
 		self.cursorPositionChanged.connect(self.highlightCurrentLine)
 		self.document().contentsChange.connect(self.contentsChange)
+		self.settings = settings
 		if globalSettings.useFakeVim:
 			self.installFakeVimHandler()
 
@@ -311,7 +312,8 @@ class ReTextEdit(QTextEdit):
 				if matchOL is not None:
 					matchedPrefix = matchOL.group(1)
 					matchedNumber = int(matchOL.group(2))
-					matchedText = matchedPrefix + str(matchedNumber + 1) + ". "
+					nextNumber = matchedNumber if self.settings.orderedListMode == 'repeat' else matchedNumber + 1
+					matchedText = matchedPrefix + str(nextNumber) + ". "
 		else:
 			matchedText = ''
 		# Reset the cursor

--- a/tests/test_editor.py
+++ b/tests/test_editor.py
@@ -25,6 +25,7 @@ from ReText.editor import documentIndentMore, documentIndentLess
 from PyQt5.QtGui import QImage, QTextCursor, QTextDocument, QKeyEvent
 from PyQt5.QtCore import Qt, QMimeData, QEvent
 from PyQt5.QtWidgets import QApplication
+from PyQt5.QtTest import QTest
 from markups import MarkdownMarkup, ReStructuredTextMarkup
 
 QApplication.setAttribute(Qt.AA_ShareOpenGLContexts)
@@ -205,6 +206,37 @@ class TestSurround(unittest.TestCase):
 		self.changeCursor(32, 38)
 		self.editor.surroundText(self.cursor, self.getEvent(Qt.Key_BracketLeft), Qt.Key_BracketLeft)
 		self.assertEqual(self.document.toPlainText(), '_foo_ *bar* "baz" \'qux\' (corge) [grault]')
+
+class TestOrderedListMode(unittest.TestCase):
+
+	class DummyReTextTab():
+		def __init__(self):
+			self.markupClass = None
+
+		def getActiveMarkupClass(self):
+			return self.markupClass
+
+	def setUp(self):
+		self.p = self
+
+	def test_increment(self):
+		editor = ReTextEdit(self)
+		editor.tab = self.DummyReTextTab()
+		QTest.keyClicks(editor, '1. Hello')
+		QTest.keyClick(editor, Qt.Key_Return)
+		QTest.keyClicks(editor, 'World')
+		self.assertEqual(editor.document().toPlainText(), '1. Hello\n2. World')
+
+	def test_repeat(self):
+		class TestSettings:
+			orderedListMode = 'repeat'
+			useFakeVim = False
+		editor = ReTextEdit(self, settings=TestSettings())
+		editor.tab = self.DummyReTextTab()
+		QTest.keyClicks(editor, '1. Hello')
+		QTest.keyClick(editor, Qt.Key_Return)
+		QTest.keyClicks(editor, 'World')
+		self.assertEqual(editor.document().toPlainText(), '1. Hello\n1. World')
 
 if __name__ == '__main__':
 	unittest.main()


### PR DESCRIPTION
Having repeating list item numbers is useful when markdown files are in version control, without it inserting an item in the middle of the list would require changing all subsequent list item numbers and causing a bigger diff in version control. We therefore prefer to write lists like so:

```
0. Foo
0. Bar
0. Baz
0. Etcetera...
```

The changes in this PR allow the user to change the current behavior of incrementing the list item number to repeating it in the ReText preferences.

I look forward to receiving feedback and updating the PR accordingly.