### PR TITLE
Don't render preview if it's disabled

### DIFF
--- a/ReText/tab.py
+++ b/ReText/tab.py
@@ -275,6 +275,8 @@ class ReTextTab(QSplitter):
 
 	def triggerPreviewUpdate(self):
 		self.previewOutdated = True
+		if self.previewState == PreviewDisabled:
+			return
 
 		if not self.conversionPending:
 			self.conversionPending = True


### PR DESCRIPTION
I've run into that while editing files on a remote server. The preview widget's HTML is updated every time a couple characters are written, and it blocks the UI. With multiple images inside, the HTML widget tries to access all the resources as files in the current directory, hitting the drive, causing a few seconds of delay when the drive is on a high latency network. When the resources are not present (draft document), it tries again later anyway. That makes typing really annoying.

With this patch, the path to even compute the HTML is cut off, so at least typing works when the preview is disabled.

There's another problem that scrolling causes the same resource access flood when scrolling the preview, but I haven't managed to get to the bottom of it. Unfortunately, strace is limited, and neither gdb nor pdb are any useful :(