### PR TITLE
docs: fix simple typo, rectagle -> rectangle

### DIFF
--- a/ReText/fakevimeditor.py
+++ b/ReText/fakevimeditor.py
@@ -132,7 +132,7 @@ class BlockSelection (QWidget):
 		self.__lineWidth = 4
 
 	def updateSelection(self, tc):
-		# block selection rectagle
+		# block selection rectangle
 		rect = self.__editor.cursorRect(tc)
 		w = rect.width()
 		tc2 = QTextCursor(tc)


### PR DESCRIPTION
There is a small typo in ReText/fakevimeditor.py.

Should read `rectangle` rather than `rectagle`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md