### PR TITLE
Move some of the config options to a separate cache file

### DIFF
--- a/ReText/__init__.py
+++ b/ReText/__init__.py
@@ -32,7 +32,7 @@ if not str(settings.fileName()).endswith('.conf'):
 	settings = QSettings(QSettings.Format.IniFormat, QSettings.Scope.UserScope,
 		'ReText project', 'ReText')
 
-cache = QSettings('ReText project', 'ReText cache')
+cache = QSettings('ReText project', 'cache')
 
 if not str(cache.fileName()).endswith('.conf'):
 	# We are on Windows probably

--- a/ReText/__init__.py
+++ b/ReText/__init__.py
@@ -32,6 +32,13 @@ if not str(settings.fileName()).endswith('.conf'):
 	settings = QSettings(QSettings.Format.IniFormat, QSettings.Scope.UserScope,
 		'ReText project', 'ReText')
 
+cache = QSettings('ReText project', 'ReText cache')
+
+if not str(cache.fileName()).endswith('.conf'):
+	# We are on Windows probably
+	cache = QSettings(QSettings.Format.IniFormat, QSettings.Scope.UserScope,
+		'ReText project', 'ReText cache')
+
 
 packageDir = abspath(dirname(__file__))
 
@@ -54,7 +61,6 @@ configOptions = {
 	'hideToolBar': False,
 	'highlightCurrentLine': 'disabled',
 	'iconTheme': '',
-	'lastTabIndex': 0,
 	'lineNumbersEnabled': False,
 	'markdownDefaultFileExtension': '.mkd',
 	'openFilesInExistingWindow': True,
@@ -80,11 +86,17 @@ configOptions = {
 	'useFakeVim': False,
 	'useWebEngine': False,
 	'wideCursor': False,
-	'windowGeometry': QByteArray(),
 	'windowTitleFullPath': False,
 }
 
-def readFromSettings(key, keytype, settings=settings, default=None):
+cacheOptions = {
+	'lastFileList': [],
+	'lastTabIndex': 0,
+	'recentFileList': [],
+	'windowGeometry': QByteArray(),
+}
+
+def readFromSettings(key, keytype, settings, default=None):
 	if not settings.contains(key):
 		return default
 	try:
@@ -98,7 +110,7 @@ def readFromSettings(key, keytype, settings=settings, default=None):
 		# Return an instance of keytype
 		return default if (default is not None) else keytype()
 
-def readListFromSettings(key, settings=settings):
+def readListFromSettings(key, settings):
 	if not settings.contains(key):
 		return []
 	value = settings.value(key)
@@ -107,13 +119,13 @@ def readListFromSettings(key, settings=settings):
 	else:
 		return value
 
-def writeToSettings(key, value, default, settings=settings):
+def writeToSettings(key, value, default, settings):
 	if value == default:
 		settings.remove(key)
 	else:
 		settings.setValue(key, value)
 
-def writeListToSettings(key, value, settings=settings):
+def writeListToSettings(key, value, settings):
 	if len(value) > 1:
 		settings.setValue(key, value)
 	elif len(value) == 1:
@@ -121,7 +133,7 @@ def writeListToSettings(key, value, settings=settings):
 	else:
 		settings.remove(key)
 
-def getSettingsFilePath(settings=settings):
+def getSettingsFilePath():
 	return settings.fileName()
 
 
@@ -130,13 +142,13 @@ class ReTextSettings:
 		for option in configOptions:
 			value = configOptions[option]
 			object.__setattr__(self, option, readFromSettings(
-				option, type(value), default=value))
+				option, type(value), default=value, settings=settings))
 
 	def __setattr__(self, option, value):
 		if not option in configOptions:
 			raise AttributeError('Unknown attribute')
 		object.__setattr__(self, option, value)
-		writeToSettings(option, value, configOptions[option])
+		writeToSettings(option, value, configOptions[option], settings=settings)
 
 	def getPreviewFont(self):
 		font = QFont()
@@ -150,6 +162,44 @@ class ReTextSettings:
 			font.fromString(self.editorFont)
 		return font
 
+class ReTextCache:
+	def __init__(self):
+		for option in cacheOptions:
+			value = cacheOptions[option]
+			if isinstance(value, list):
+				object.__setattr__(self, option, readListFromSettings(
+					option, settings=cache))
+			else:
+				object.__setattr__(self, option, readFromSettings(
+					option, type(value), default=value, settings=cache))
+
+	def __setattr__(self, option, value):
+		if not option in cacheOptions:
+			raise AttributeError('Unknown attribute')
+		default = cacheOptions[option]
+		if isinstance(default, list):
+			object.__setattr__(self, option, value.copy())
+			writeListToSettings(option, value, settings=cache)
+		else:
+			object.__setattr__(self, option, value)
+			writeToSettings(option, value, cacheOptions[option], settings=cache)
+
+def moveSettingsToCache():
+	# Moves the non-editable config options to the cache file
+	# This is here for backwards compatibility
+	for option in cacheOptions:
+		if not cache.contains(option):
+			default = cacheOptions[option]
+			if isinstance(default, list):
+				value = readListFromSettings(option, settings)
+				writeListToSettings(option, value, cache)
+			else:
+				value = readFromSettings(option, type(default), settings, default)
+				writeToSettings(option, value, default, cache)
+		settings.remove(option)
+
+moveSettingsToCache()
 globalSettings = ReTextSettings()
+globalCache = ReTextCache()
 
 markups.common.PYGMENTS_STYLE = globalSettings.pygmentsStyle

--- a/ReText/__init__.py
+++ b/ReText/__init__.py
@@ -37,7 +37,7 @@ cache = QSettings('ReText project', 'cache')
 if not str(cache.fileName()).endswith('.conf'):
 	# We are on Windows probably
 	cache = QSettings(QSettings.Format.IniFormat, QSettings.Scope.UserScope,
-		'ReText project', 'ReText cache')
+		'ReText project', 'cache')
 
 
 packageDir = abspath(dirname(__file__))

--- a/ReText/__main__.py
+++ b/ReText/__main__.py
@@ -24,7 +24,7 @@ import signal
 import markups
 from os import devnull
 from os.path import join
-from ReText import packageDir, settings, globalSettings, app_version
+from ReText import packageDir, settings, cache, globalSettings, app_version
 from ReText.window import ReTextWindow
 
 from PyQt6.QtCore import QCommandLineOption, QCommandLineParser, QFile, \
@@ -94,6 +94,7 @@ def main():
 	filesToOpen = parser.positionalArguments()
 
 	print('Using configuration file:', settings.fileName())
+	print('Using cache file:', cache.fileName())
 	if globalSettings.appStyleSheet:
 		sheetfile = QFile(globalSettings.appStyleSheet)
 		sheetfile.open(QIODevice.OpenModeFlag.ReadOnly)

--- a/ReText/window.py
+++ b/ReText/window.py
@@ -22,7 +22,8 @@ import os
 from subprocess import Popen
 import warnings
 
-from ReText import getBundledIcon, app_version, globalSettings, globalCache
+from ReText import (getBundledIcon, app_version, globalSettings, globalCache, 
+	readListFromSettings, writeListToSettings)
 from ReText.tab import (ReTextTab, ReTextWebEnginePreview,
                         PreviewDisabled, PreviewNormal, PreviewLive)
 from ReText.dialogs import EncodingDialog, HtmlDialog, LocaleDialog

--- a/ReText/window.py
+++ b/ReText/window.py
@@ -22,8 +22,7 @@ import os
 from subprocess import Popen
 import warnings
 
-from ReText import (getBundledIcon, app_version, globalSettings, globalCache, 
-	readListFromSettings, writeListToSettings)
+from ReText import getBundledIcon, app_version, globalSettings, globalCache
 from ReText.tab import (ReTextTab, ReTextWebEnginePreview,
                         PreviewDisabled, PreviewNormal, PreviewLive)
 from ReText.dialogs import EncodingDialog, HtmlDialog, LocaleDialog

--- a/tests/test_window.py
+++ b/tests/test_window.py
@@ -57,8 +57,8 @@ class TestWindow(unittest.TestCase):
 
     def setUp(self):
         warnings.simplefilter("ignore", Warning)
-        self.readListFromSettingsMock = patch('ReText.window.readListFromSettings', return_value=[]).start()
-        self.writeListToSettingsMock  = patch('ReText.window.writeListToSettings').start()
+        self.readListFromSettingsMock = patch('ReText.readListFromSettings', return_value=[]).start()
+        self.writeListToSettingsMock  = patch('ReText.writeListToSettings').start()
         self.globalSettingsMock       = patch('ReText.window.globalSettings', MagicMock(**ReText.configOptions)).start()
         self.globalCacheMock          = patch('ReText.window.globalCache', MagicMock(**ReText.cacheOptions)).start()
         self.fileSystemWatcherPatcher = patch('ReText.window.QFileSystemWatcher')

--- a/tests/test_window.py
+++ b/tests/test_window.py
@@ -57,7 +57,10 @@ class TestWindow(unittest.TestCase):
 
     def setUp(self):
         warnings.simplefilter("ignore", Warning)
+        self.readListFromSettingsMock = patch('ReText.window.readListFromSettings', return_value=[]).start()
+        self.writeListToSettingsMock  = patch('ReText.window.writeListToSettings').start()
         self.globalSettingsMock       = patch('ReText.window.globalSettings', MagicMock(**ReText.configOptions)).start()
+        self.globalCacheMock          = patch('ReText.window.globalCache', MagicMock(**ReText.cacheOptions)).start()
         self.fileSystemWatcherPatcher = patch('ReText.window.QFileSystemWatcher')
         self.fileSystemWatcherMock    = self.fileSystemWatcherPatcher.start()
         ReText.tab.globalSettings = self.globalSettingsMock

--- a/tests/test_window.py
+++ b/tests/test_window.py
@@ -57,8 +57,6 @@ class TestWindow(unittest.TestCase):
 
     def setUp(self):
         warnings.simplefilter("ignore", Warning)
-        self.readListFromSettingsMock = patch('ReText.window.readListFromSettings', return_value=[]).start()
-        self.writeListToSettingsMock  = patch('ReText.window.writeListToSettings').start()
         self.globalSettingsMock       = patch('ReText.window.globalSettings', MagicMock(**ReText.configOptions)).start()
         self.fileSystemWatcherPatcher = patch('ReText.window.QFileSystemWatcher')
         self.fileSystemWatcherMock    = self.fileSystemWatcherPatcher.start()


### PR DESCRIPTION
Some of the settings described in the `configuration.md` file are said to be editable by ReText only, not by the user. Therefore, it makes sense to store them in separate files.

One possible scenario would be if the user wanted to save their configuration. Now they can save the `ReText.conf` file and use it on another instance of ReText without affecting the config entries that should not be user editable. I came across this issue when I wanted to save the `ReText.conf` file to be tracked by my dotfiles repository, but I had trouble with the `recentFileList` entry, since I did not want to track those.

There are still some issues with this implementation. One of them is that the cache file is created with the same QSettings class as the main config file and its name does not perfectly match its intention.