### PR TITLE
.desktop suffix deprecated with setDesktopFileName()

### DIFF
--- a/ReText/__main__.py
+++ b/ReText/__main__.py
@@ -65,7 +65,7 @@ def main():
 	app.setApplicationDisplayName("ReText")
 	app.setApplicationVersion(app_version)
 	app.setOrganizationDomain('mitya57.me')
-	app.setDesktopFileName('me.mitya57.ReText.desktop')
+	app.setDesktopFileName('me.mitya57.ReText')
 	QNetworkProxyFactory.setUseSystemConfiguration(True)
 
 	RtTranslator = QTranslator()


### PR DESCRIPTION
QGuiApplication::setDesktopFileName: the specified desktop file name ends with .desktop. For compatibility reasons, the .desktop suffix will be removed. Please specify a desktop file name without .desktop suffix

---

The Qt documentation used to be a bit ambiguous on this but now they have clarified.