### PR TITLE
Tabs' Context Menu

### DIFF
--- a/ReText/tabactiontypes.py
+++ b/ReText/tabactiontypes.py
@@ -6,6 +6,9 @@ class TabActionTypes(StrEnum):
 
     Unknown = ''
 
+    CopyFileName = QObject.tr('Copy File Name')
+    CopyFilePath = QObject.tr('Copy file path')
+
     Close = QObject.tr('Close')
     CloseAll = QObject.tr('Close All Tabs')
     CloseOther = QObject.tr('Close Other Tabs')

--- a/ReText/tabactiontypes.py
+++ b/ReText/tabactiontypes.py
@@ -1,0 +1,15 @@
+from enum import StrEnum
+
+from PyQt6.QtCore import QObject
+
+class TabActionTypes(StrEnum):
+
+    Unknown = ''
+
+    Close = QObject.tr('Close')
+    CloseAll = QObject.tr('Close All Tabs')
+    CloseOther = QObject.tr('Close Other Tabs')
+    CloseUnmodified = QObject.tr('Close Unmodified Tabs')
+    CloseToLeft = QObject.tr('Close Tabs to the Left')
+    CloseToRight = QObject.tr('Close Tabs to the Right')
+

--- a/ReText/window.py
+++ b/ReText/window.py
@@ -535,7 +535,9 @@ class ReTextWindow(QMainWindow):
                 action = menu.addAction(action_type.value)
                 action.target_tab_pos = clicked_tab_index
                 actions[action_type] = action
-
+            if action_type is TabActionTypes.CopyFilePath:
+                menu.addSeparator()
+            
         total_tabs = self.tabWidget.count()
         actions[TabActionTypes.CloseToLeft].setEnabled(clicked_tab_index > 0)
         actions[TabActionTypes.CloseToRight].setEnabled(clicked_tab_index < total_tabs-1)

--- a/ReText/window.py
+++ b/ReText/window.py
@@ -535,6 +535,8 @@ class ReTextWindow(QMainWindow):
         if not clicked_tab:
             raise RuntimeWarning(f"No tab found at index {clicked_tab_index}.")
 
+        self.tabWidget.setCurrentIndex(clicked_tab_index)
+        
         actions = {}
 
         for action_type in TabActionTypes:

--- a/ReText/window.py
+++ b/ReText/window.py
@@ -522,6 +522,20 @@ class ReTextWindow(QMainWindow):
 
         self._init_tabs_context_menu()
 
+    def _init_tabs_context_menu(self):
+        tabBar = self.tabWidget.tabBar()
+        tabBar.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
+        tabBar.customContextMenuRequested.connect(self._on_tab_context_menu_requested)
+
+        self._tabs_ctx_menu = QMenu(self)
+        self._tabs_ctx_menu_actions = {}
+
+        for action_type in TabActionTypes:
+            if action_type is not TabActionTypes.Unknown:
+                self._tabs_ctx_menu_actions[action_type] = self._tabs_ctx_menu.addAction(action_type.value)
+            if action_type is TabActionTypes.CopyFilePath:
+                self._tabs_ctx_menu.addSeparator()
+
     def _on_tab_context_menu_requested(self, p):
 
         clicked_tab_index = self.tabWidget.tabBar().tabAt(p)
@@ -543,13 +557,14 @@ class ReTextWindow(QMainWindow):
         self._tabs_ctx_menu_actions[TabActionTypes.CopyFileName].setEnabled(can_copy_file)
         self._tabs_ctx_menu_actions[TabActionTypes.CopyFilePath].setEnabled(can_copy_file)
 
+        self._tabs_ctx_menu_actions[TabActionTypes.CloseAll].setEnabled(total_tabs > 1)
         self._tabs_ctx_menu_actions[TabActionTypes.CloseToLeft].setEnabled(clicked_tab_index > 0)
         self._tabs_ctx_menu_actions[TabActionTypes.CloseToRight].setEnabled(clicked_tab_index < total_tabs-1)
         self._tabs_ctx_menu_actions[TabActionTypes.CloseOther].setEnabled(total_tabs > 1)
 
         has_unmodified = any(not self.tabWidget.widget(i).editBox.document().isModified()
                              for i in range(self.tabWidget.count()))
-        self._tabs_ctx_menu_actions[TabActionTypes.CloseUnmodified].setEnabled(has_unmodified)
+        self._tabs_ctx_menu_actions[TabActionTypes.CloseUnmodified].setEnabled(has_unmodified and total_tabs > 1)
 
         chosen_action = self._tabs_ctx_menu.exec(p)
         self._handle_tab_context_action(chosen_action)
@@ -1461,18 +1476,3 @@ class ReTextWindow(QMainWindow):
         for tab in self.iterateTabs():
             if not tab.fileName:
                 tab.updateActiveMarkupClass()
-
-    def _init_tabs_context_menu(self):
-        tabBar = self.tabWidget.tabBar()
-        tabBar.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
-        tabBar.customContextMenuRequested.connect(self._on_tab_context_menu_requested)
-
-        self._tabs_ctx_menu = QMenu(self)
-        self._tabs_ctx_menu_actions = {}
-
-        for action_type in TabActionTypes:
-            if action_type is not TabActionTypes.Unknown:
-                self._tabs_ctx_menu_actions[action_type] = self._tabs_ctx_menu.addAction(action_type.value)
-            if action_type is TabActionTypes.CopyFilePath:
-                self._tabs_ctx_menu.addSeparator()
-                

--- a/ReText/window.py
+++ b/ReText/window.py
@@ -528,6 +528,13 @@ class ReTextWindow(QMainWindow):
         menu = QMenu(self)
 
         clicked_tab_index = self.tabWidget.tabBar().tabAt(p)
+        if -1 == clicked_tab_index:
+            raise RuntimeWarning(f"No tab found at [{p.x()};{p.y()}].")
+
+        clicked_tab = self.tabWidget.widget(clicked_tab_index)
+        if not clicked_tab:
+            raise RuntimeWarning(f"No tab found at index {clicked_tab_index}.")
+
         actions = {}
 
         for action_type in TabActionTypes:
@@ -540,7 +547,6 @@ class ReTextWindow(QMainWindow):
 
         total_tabs = self.tabWidget.count()
 
-        clicked_tab = self.tabWidget.widget(clicked_tab_index)
         can_copy_file = clicked_tab and QFileInfo.exists(clicked_tab.fileName)
         actions[TabActionTypes.CopyFileName].setEnabled(can_copy_file)
         actions[TabActionTypes.CopyFilePath].setEnabled(can_copy_file)


### PR DESCRIPTION
This PR introduces a tab's RMB-click menu with dynamically available actions for copying file location info and advanced closing options:

- **Right-click**: activates the selected tab and opens a persistent context menu.  
- **Copy File Name**: Copies the file name of the clicked tab, if available.  
- **Copy File Path**: Copies the absolute file path of the clicked tab, if available.  
- **Close**: Closes the clicked tab.  
- **Close All Tabs**: Closes all tabs; enabled if 2+ tabs are open.  
- **Close Other Tabs**: Closes all tabs except the clicked one; enabled if 2+ tabs are open.  
- **Close Unmodified Tabs**: Closes tabs with no unsaved changes; enabled if 2+ tabs are open.  
- **Close Tabs to the Left/Right**: Closes all tabs in the specified direction; enabled if 2+ tabs are open and the clicked one is not at the edge.

![image](https://github.com/user-attachments/assets/24969923-f36e-4a17-a689-ad540294cfe8)