### PR TITLE
Retry re-watching a file after it is replaced instead of edited in place

### DIFF
--- a/ReText/window.py
+++ b/ReText/window.py
@@ -102,6 +102,10 @@ previewStatesByName = {
     'live-preview': PreviewLive,
 }
 
+# See rewatchFile() for what these are used for.
+REWATCH_RETRY_INTERVAL = 200  # milliseconds
+MAX_REWATCH_ATTEMPTS = 10
+
 
 class ReTextWindow(QMainWindow):
     def __init__(self, parent=None):
@@ -974,9 +978,8 @@ class ReTextWindow(QMainWindow):
             elif globalSettings.defaultPreviewState == "normal-preview":
                 self.actionPreview.setChecked(True)
                 self.preview(True)
-            if fileName:
-                self.fileSystemWatcher.addPath(fileName)
             if QFile.exists(fileName):
+                self.rewatchFile(fileName)
                 self.currentTab.readTextFromFile(fileName)
             else:
                 self.currentTab.fileName = fileName
@@ -1291,9 +1294,38 @@ class ReTextWindow(QMainWindow):
             messageBox.exec()
             if messageBox.clickedButton() is reloadButton:
                 tab.readTextFromFile()
-        if fileName not in self.fileSystemWatcher.files():
-            # https://github.com/retext-project/retext/issues/137
-            self.fileSystemWatcher.addPath(fileName)
+        self.rewatchFile(fileName)
+
+    def rewatchFile(self, fileName, attempt=0):
+        '''
+        (Re-)adds fileName to the file system watcher, unless it is
+        already watched. https://github.com/retext-project/retext/issues/137
+
+        Many applications do not save files in place: they write a new
+        file and then rename it over the original. That replaces the
+        file the operating system watch refers to, so the watch has to
+        be re-created after every such change.
+
+        Right after the change is reported, the new file may not be in
+        place yet (a delete-then-recreate save may still be in progress),
+        and then addPath fails and returns False. Retry a few times with
+        a short delay in that case, instead of silently leaving the file
+        unwatched for the rest of the session.
+        '''
+        if attempt > 0 and not any(tab.fileName == fileName for tab in self.iterateTabs()):
+            # The tab was closed while we were waiting for the file to
+            # reappear. Only checked when retrying: on the first attempt
+            # the tab may not have been given its file name yet.
+            return
+        if fileName in self.fileSystemWatcher.files():
+            return
+        if QFile.exists(fileName) and self.fileSystemWatcher.addPath(fileName):
+            return
+        if attempt < MAX_REWATCH_ATTEMPTS:
+            QTimer.singleShot(
+                REWATCH_RETRY_INTERVAL,
+                lambda: self.rewatchFile(fileName, attempt + 1),
+            )
 
     def maybeSave(self, ind):
         tab = self.tabWidget.widget(ind)

--- a/tests/test_window.py
+++ b/tests/test_window.py
@@ -33,7 +33,7 @@ from PyQt6.QtTest import QTest
 from PyQt6.QtWidgets import QApplication, QMessageBox
 
 import ReText
-from ReText.window import ReTextWindow
+from ReText.window import MAX_REWATCH_ATTEMPTS, REWATCH_RETRY_INTERVAL, ReTextWindow
 
 path_to_testdata = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'testdata')
 
@@ -514,6 +514,86 @@ class TestWindow(unittest.TestCase):
         QTest.qWait(100)
         self.assertEqual(editBox.toPlainText(), 'modified first content')
         self.assertTrue(window.currentTab.forceDisableAutoSave)
+
+        window.closeTab(0)
+        self.assertEqual(window.fileSystemWatcher.files(), [])
+        with suppress(PermissionError):
+            os.remove(fileName)
+
+    @unittest.skipIf(platform.system() == 'Windows', 'QFileSystemWatcher does not work reliably')
+    @patch('ReText.window.QMessageBox.exec', return_value=None)
+    def test_reloadFileReplacedAtomically(self, messageBoxExecMock):
+        # Many applications do not save files in place: they write a new
+        # file and rename it over the original. That replaces the file
+        # the watch refers to, so it has to be re-created every time.
+        # See https://github.com/retext-project/retext/issues/137
+        self.fileSystemWatcherPatcher.stop()
+        window = ReTextWindow()
+        handle, fileName = tempfile.mkstemp(suffix='.mkd')
+        os.close(handle)  # the file has to be replaceable and removable
+        with open(fileName, 'w', encoding='utf-8') as tempFile:
+            tempFile.write('first content')
+        window.openFileWrapper(fileName)
+        self.assertEqual(window.fileSystemWatcher.files(), [fileName.replace('\\', '/')])
+        editBox = window.currentTab.editBox
+        self.assertEqual(editBox.toPlainText(), 'first content')
+        app.processEvents()
+
+        def replaceAtomically(content):
+            tmpName = fileName + '.tmp'
+            with open(tmpName, 'w', encoding='utf-8') as tempFile:
+                tempFile.write(content)
+            os.replace(tmpName, fileName)
+
+        replaceAtomically('modified externally once')
+        QTest.qWait(100)
+        self.assertEqual(editBox.toPlainText(), 'modified externally once')
+        self.assertEqual(window.fileSystemWatcher.files(), [fileName.replace('\\', '/')])
+
+        # A second replacement must be detected as well, which means the
+        # watch was re-established after the first one.
+        replaceAtomically('modified externally twice')
+        QTest.qWait(100)
+        self.assertEqual(editBox.toPlainText(), 'modified externally twice')
+        self.assertEqual(window.fileSystemWatcher.files(), [fileName.replace('\\', '/')])
+
+        window.closeTab(0)
+        self.assertEqual(window.fileSystemWatcher.files(), [])
+        with suppress(PermissionError):
+            os.remove(fileName)
+
+    @unittest.skipIf(platform.system() == 'Windows', 'QFileSystemWatcher does not work reliably')
+    @patch('ReText.window.QMessageBox.warning', return_value=QMessageBox.StandardButton.Discard)
+    @patch('ReText.window.QMessageBox.exec', return_value=None)
+    def test_rewatchFileAfterItReappears(self, messageBoxExecMock, messageBoxWarningMock):
+        # Some saves remove the file before writing the new one, so it is
+        # briefly absent. The watch cannot be re-created while that is the
+        # case, and giving up then would leave the file unwatched forever.
+        self.fileSystemWatcherPatcher.stop()
+        window = ReTextWindow()
+        handle, fileName = tempfile.mkstemp(suffix='.mkd')
+        os.close(handle)  # the file has to be replaceable and removable
+        with open(fileName, 'w', encoding='utf-8') as tempFile:
+            tempFile.write('first content')
+        window.openFileWrapper(fileName)
+        self.assertEqual(window.fileSystemWatcher.files(), [fileName.replace('\\', '/')])
+        editBox = window.currentTab.editBox
+        self.assertEqual(editBox.toPlainText(), 'first content')
+        app.processEvents()
+
+        os.remove(fileName)
+        QTest.qWait(100)  # let the watcher notice that the file is gone
+        with open(fileName, 'w', encoding='utf-8') as tempFile:
+            tempFile.write('recreated externally')
+        QTest.qWait(MAX_REWATCH_ATTEMPTS * REWATCH_RETRY_INTERVAL)
+        self.assertEqual(window.fileSystemWatcher.files(), [fileName.replace('\\', '/')])
+
+        # The watch has to be functional again, not merely registered.
+        editBox.document().setModified(False)
+        with open(fileName, 'w', encoding='utf-8') as tempFile:
+            tempFile.write('modified after recreation')
+        QTest.qWait(100)
+        self.assertEqual(editBox.toPlainText(), 'modified after recreation')
 
         window.closeTab(0)
         self.assertEqual(window.fileSystemWatcher.files(), [])


### PR DESCRIPTION
Refs #137.

## Problem

Auto-reload of externally modified files stops working after the first change
when the other application does not write the file in place.

Most editors and many tools save with the "atomic save" pattern: write the new
content to a temporary file, then rename it over the original. The path then
refers to a different file than the one the OS-level watch was created for, so
`QFileSystemWatcher` reports the first change and then goes silent for that
path — the symptom described in #137 ("fileChanged is only triggered once").

`fileChanged()` already worked around this by re-adding the path after every
change, but it called `addPath()` once and ignored its return value. If the new
file was not in place at that exact moment — a save that deletes and recreates
the file, or simply a slow filesystem — `addPath()` failed and the file stayed
unwatched for the rest of the session, with no way for the user to notice or
recover other than reopening the tab.

## Change

`rewatchFile()` replaces the single blind `addPath()` call:

- it skips files that are already watched;
- it checks that `addPath()` actually succeeded;
- if it did not, it retries every 200 ms for up to 10 attempts (~2 s), giving
up early if the tab is closed in the meantime.

It is also used when opening a file, since the same race exists if the file
happens to be written at the moment it is opened.

## Tests

Two tests are added to `tests/test_window.py`:

- `test_reloadFileReplacedAtomically` — a file replaced twice via
`os.replace()`; both changes have to be picked up, which requires the watch
to be re-created after the first one.
- `test_rewatchFileAfterItReappears` — the file is removed, the watcher is
given time to notice, and the file is then recreated. This is the case the
retry exists for.

Both follow the existing convention of the sibling watcher tests and are
skipped on Windows, so they run on the Linux jobs. I verified them on Debian:
the whole suite passes, and `test_rewatchFileAfterItReappears` fails without
this change — checked by setting `MAX_REWATCH_ATTEMPTS` to 0, which reduces
`rewatchFile()` to the previous single `addPath()` call, and the watcher is
then left with no watched files at all. So it covers the failure mode from the
issue, not just the atomic-rename case.

Out of curiosity I also ran all four watcher tests unskipped on Windows 10 with
PyQt6 6.11 and they pass there, once the path assertion is adjusted to native
separators — `QFileSystemWatcher.files()` appears to keep backslashes on
Windows, so the existing `fileName.replace('\\', '/')` in those tests looks
like it would not match there. I left that alone to keep this change focused.

I also verified the fix by hand in the running application: with an external
script replacing the open file every few seconds, the preview now follows every
change, where before it updated only once.
 