### PR TITLE
Add a savePreviewState option to restore the preview state per document

### DIFF
--- a/ReText/__init__.py
+++ b/ReText/__init__.py
@@ -73,6 +73,7 @@ configOptions = {
     'restDefaultFileExtension': '.rst',
     'rightMargin': 0,
     'rightMarginWrap': False,
+    'savePreviewState': False,
     'saveWindowGeometry': False,
     'scrollFactor': 1.0,
     'showDirectoryTree': False,
@@ -92,6 +93,7 @@ configOptions = {
 
 cacheOptions = {
     'lastFileList': [],
+    'lastPreviewStateList': [],
     'lastTabIndex': 0,
     'recentFileList': [],
     'splitterState': QByteArray(),

--- a/ReText/config.py
+++ b/ReText/config.py
@@ -131,6 +131,7 @@ class ConfigDialog(QDialog):
             (self.tr('Behavior'), (
                 (self.tr('Automatically save documents'), 'autoSave'),
                 (self.tr('Automatically open last documents on startup'), 'openLastFilesOnStartup'),
+                (self.tr('Restore preview state of last documents'), 'savePreviewState'),
                 (self.tr('Number of recent documents'), 'recentDocumentsCount'),
                 (self.tr('Restore window geometry'), 'saveWindowGeometry'),
                 (self.tr('Default preview state'), 'defaultPreviewState'),

--- a/ReText/window.py
+++ b/ReText/window.py
@@ -102,6 +102,8 @@ previewStatesByName = {
     'live-preview': PreviewLive,
 }
 
+previewStateNames = {state: name for name, state in previewStatesByName.items()}
+
 # See rewatchFile() for what these are used for.
 REWATCH_RETRY_INTERVAL = 200  # milliseconds
 MAX_REWATCH_ATTEMPTS = 10
@@ -494,8 +496,15 @@ class ReTextWindow(QMainWindow):
         self.fileSystemWatcher.fileChanged.connect(self.fileChanged)
 
     def restoreLastOpenedFiles(self):
-        for file in globalCache.lastFileList:
-            self.openFileWrapper(file)
+        previewStates = []
+        if globalSettings.savePreviewState:
+            previewStates = globalCache.lastPreviewStateList
+        for index, file in enumerate(globalCache.lastFileList):
+            # The saved state wins over defaultPreviewState.
+            previewState = None
+            if index < len(previewStates):
+                previewState = previewStatesByName.get(previewStates[index], PreviewDisabled)
+            self.openFileWrapper(file, previewState)
 
         # Show the tab of last opened file
         lastTabIndex = globalCache.lastTabIndex
@@ -633,8 +642,10 @@ class ReTextWindow(QMainWindow):
             self.updateTabTitle(self.ind, tab)
             self.setWindowModified(changed)
 
-    def createTab(self, fileName):
-        previewState = previewStatesByName.get(globalSettings.defaultPreviewState, PreviewDisabled)
+    def createTab(self, fileName, previewState=None):
+        if previewState is None:
+            previewState = previewStatesByName.get(globalSettings.defaultPreviewState,
+                                                   PreviewDisabled)
         if previewState == PreviewNormal and not fileName:
             previewState = PreviewDisabled  # Opening empty document in preview mode makes no sense
         self.currentTab = ReTextTab(self, fileName, previewState)
@@ -708,6 +719,19 @@ class ReTextWindow(QMainWindow):
         globalSettings.font = font.toString()
         for tab in self.iterateTabs():
             tab.triggerPreviewUpdate()
+
+    def setPreviewState(self, previewState):
+        '''
+        Switches the current tab to previewState. The menu actions are
+        only checked, not triggered, so each of them has to be paired
+        with its handler by hand.
+        '''
+        if previewState == PreviewLive:
+            self.actionLivePreview.setChecked(True)
+            self.enableLivePreview(True)
+        else:
+            self.actionPreview.setChecked(previewState == PreviewNormal)
+            self.preview(previewState == PreviewNormal)
 
     def preview(self, viewmode):
         self.currentTab.previewState = viewmode * 2
@@ -953,7 +977,7 @@ class ReTextWindow(QMainWindow):
             self.openFileWrapper(fileName)
 
     @pyqtSlot(str)
-    def openFileWrapper(self, fileName):
+    def openFileWrapper(self, fileName, previewState=None):
         if not fileName:
             return
         fileName = os.path.abspath(fileName)
@@ -972,9 +996,11 @@ class ReTextWindow(QMainWindow):
                 self.currentTab.editBox.document().isModified()
             )
             if noEmptyTab:
-                self.createTab(fileName)
+                self.createTab(fileName, previewState)
                 self.ind = self.tabWidget.count()-1
                 self.tabWidget.setCurrentIndex(self.ind)
+            elif previewState is not None:
+                self.setPreviewState(previewState)
             elif globalSettings.defaultPreviewState == "normal-preview":
                 self.actionPreview.setChecked(True)
                 self.preview(True)
@@ -1366,6 +1392,11 @@ class ReTextWindow(QMainWindow):
             files = [tab.fileName for tab in self.iterateTabs()]
             globalCache.lastFileList = files
             globalCache.lastTabIndex = self.tabWidget.currentIndex()
+            if globalSettings.savePreviewState:
+                globalCache.lastPreviewStateList = [
+                    previewStateNames[tab.previewState] for tab in self.iterateTabs()]
+            else:
+                globalCache.lastPreviewStateList = []
         closeevent.accept()
 
     def viewHtml(self):

--- a/configuration.md
+++ b/configuration.md
@@ -34,6 +34,7 @@ option name                    | type      | description
 `restDefaultFileExtension`     | string    | default file extension for reStructuredText files (default: `.rst`)
 `rightMargin`                  | integer   | enable drawing of vertical line on defined position (or 0 to disable)
 `rightMarginWrap`              | boolean   | enable soft wrap at specified margin line (default: false)
+`savePreviewState`             | boolean   | whether to restore the preview state each of the last documents was closed in, falling back to `defaultPreviewState`; requires `openLastFilesOnStartup` (default: false)
 `saveWindowGeometry`           | boolean   | whether to restore window geometry from previous session (default: false)
 `scrollFactor`                 | float     | scrolling speed factor (default: 1.0)
 `showDirectoryTree`            | boolean   | whether to show a directory tree on the left side of the window (default: false)

--- a/tests/test_window.py
+++ b/tests/test_window.py
@@ -28,11 +28,12 @@ from unittest.mock import MagicMock, patch
 import markups
 from markups.abstract import ConvertedMarkup
 from PyQt6.QtCore import QObject, Qt, pyqtSignal
-from PyQt6.QtGui import QTextCursor
+from PyQt6.QtGui import QFont, QTextCursor
 from PyQt6.QtTest import QTest
 from PyQt6.QtWidgets import QApplication, QMessageBox
 
 import ReText
+from ReText.tab import PreviewDisabled, PreviewLive, PreviewNormal
 from ReText.window import MAX_REWATCH_ATTEMPTS, REWATCH_RETRY_INTERVAL, ReTextWindow
 
 path_to_testdata = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'testdata')
@@ -64,6 +65,11 @@ class TestWindow(unittest.TestCase):
             'ReText.window.globalSettings',
             MagicMock(**ReText.configOptions),
         ).start()
+        # configOptions only holds the option values, so the mock has no
+        # working getPreviewFont: without this, any tab left in a preview
+        # state passes a MagicMock to QTextDocument.setDefaultFont, and
+        # the exception in the slot takes the whole process down.
+        self.globalSettingsMock.getPreviewFont.return_value = QFont()
         self.globalCacheMock = patch(
             'ReText.window.globalCache',
             MagicMock(**ReText.cacheOptions),
@@ -599,6 +605,57 @@ class TestWindow(unittest.TestCase):
         self.assertEqual(window.fileSystemWatcher.files(), [])
         with suppress(PermissionError):
             os.remove(fileName)
+
+    def test_savePreviewState(self):
+        self.globalSettingsMock.openLastFilesOnStartup = True
+        self.globalSettingsMock.savePreviewState = True
+        fileName = os.path.join(path_to_testdata, 'existing_file.md')
+
+        window = ReTextWindow()
+        window.openFileWrapper(fileName)
+        window.setPreviewState(PreviewLive)
+        self.assertEqual(window.currentTab.previewState, PreviewLive)
+        window.close()
+        self.assertEqual(self.globalCacheMock.lastFileList, [fileName])
+        self.assertEqual(self.globalCacheMock.lastPreviewStateList, ['live-preview'])
+
+        # Reopening the document has to bring the live preview back.
+        restoredWindow = ReTextWindow()
+        restoredWindow.restoreLastOpenedFiles()
+        self.assertEqual(restoredWindow.currentTab.fileName, fileName)
+        self.assertEqual(restoredWindow.currentTab.previewState, PreviewLive)
+
+    def test_savePreviewStateOverridesDefaultPreviewState(self):
+        # A document closed in the editor stays in the editor, even when
+        # defaultPreviewState asks for a preview.
+        self.globalSettingsMock.openLastFilesOnStartup = True
+        self.globalSettingsMock.savePreviewState = True
+        self.globalSettingsMock.defaultPreviewState = 'live-preview'
+        self.globalCacheMock.lastFileList = [os.path.join(path_to_testdata, 'existing_file.md')]
+        self.globalCacheMock.lastPreviewStateList = ['editor']
+
+        window = ReTextWindow()
+        window.restoreLastOpenedFiles()
+        self.assertEqual(window.currentTab.previewState, PreviewDisabled)
+
+    def test_savePreviewStateDisabled(self):
+        self.globalSettingsMock.openLastFilesOnStartup = True
+        self.globalSettingsMock.savePreviewState = False
+        self.globalSettingsMock.defaultPreviewState = 'normal-preview'
+        fileName = os.path.join(path_to_testdata, 'existing_file.md')
+
+        window = ReTextWindow()
+        window.openFileWrapper(fileName)
+        self.assertEqual(window.currentTab.previewState, PreviewNormal)
+        window.setPreviewState(PreviewDisabled)
+        window.close()
+        self.assertEqual(self.globalCacheMock.lastPreviewStateList, [])
+
+        # With the option off, defaultPreviewState decides, as before.
+        self.globalCacheMock.lastPreviewStateList = ['editor']
+        restoredWindow = ReTextWindow()
+        restoredWindow.restoreLastOpenedFiles()
+        self.assertEqual(restoredWindow.currentTab.previewState, PreviewNormal)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Add savePreviewState, which stores the preview state of each of the last opened documents when ReText exits and restores it when those documents are reopened. It builds on the existing session restore, so it goes together with openLastFilesOnStartup, and it falls back to defaultPreviewState for documents with no saved state.

The state is kept in the cache file next to lastFileList, using the same names defaultPreviewState already accepts.

The tests need one fix to the existing setUp to be able to cover this: the settings mock is built from configOptions, which only holds option values, so it has no working getPreviewFont(). Any tab left in a preview state then passes a MagicMock to QTextDocument.setDefaultFont, and since that happens in a slot, the exception aborts the whole test process instead of failing a single test.